### PR TITLE
Removed SQRLBackupURLKey parameter

### DIFF
--- a/Squirrel/SQRLArguments.h
+++ b/Squirrel/SQRLArguments.h
@@ -25,7 +25,6 @@ extern const char * const SQRLShipItCommandKey;
 //
 //	- SQRLTargetBundleURLKey
 //	- SQRLUpdateBundleURLKey
-//	- SQRLBackupURLKey
 //	- SQRLShouldRelaunchKey
 //	- SQRLWaitForConnectionKey
 //
@@ -59,12 +58,6 @@ extern const char * const SQRLTargetBundleURLKey;
 //
 // This argument is required.
 extern const char * const SQRLUpdateBundleURLKey;
-
-// Associated with a string representation of the URL to a directory in which
-// the target bundle should be backed up before beginning installation.
-//
-// This argument is required.
-extern const char * const SQRLBackupURLKey;
 
 // Associated with a boolean which indicates whether the application should be
 // launched after being updated.

--- a/Squirrel/SQRLArguments.m
+++ b/Squirrel/SQRLArguments.m
@@ -18,6 +18,5 @@ const char * const SQRLProcessIdentifierKey = "SQRLProcessIdentifierKey";
 const char * const SQRLBundleIdentifierKey = "SQRLBundleIdentifierKey";
 const char * const SQRLTargetBundleURLKey = "SQRLTargetBundleURLKey";
 const char * const SQRLUpdateBundleURLKey = "SQRLUpdateBundleURLKey";
-const char * const SQRLBackupURLKey = "SQRLBackupURLKey";
 const char * const SQRLShouldRelaunchKey = "SQRLShouldRelaunchKey";
 const char * const SQRLCodeSigningRequirementKey = "SQRLCodeSigningRequirementKey";

--- a/Squirrel/SQRLInstaller.h
+++ b/Squirrel/SQRLInstaller.h
@@ -42,7 +42,7 @@ extern const NSInteger SQRLInstallerErrorInvalidBundleVersion;
 //                   nil.
 //
 // Returns an initialized installer, or nil if an error occurred.
-- (id)initWithTargetBundleURL:(NSURL *)targetBundleURL updateBundleURL:(NSURL *)updateBundleURL backupURL:(NSURL *)backupURL requirementData:(NSData *)requirementData;
+- (id)initWithTargetBundleURL:(NSURL *)targetBundleURL updateBundleURL:(NSURL *)updateBundleURL requirementData:(NSData *)requirementData;
 
 // Attempts to install the update specified at the time of initialization.
 - (BOOL)installUpdateWithError:(NSError **)errorPtr;

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -399,7 +399,6 @@ const NSInteger SQRLUpdaterErrorRetrievingCodeSigningRequirement = 4;
 	xpc_dictionary_set_string(message, SQRLShipItCommandKey, SQRLShipItInstallCommand);
 	xpc_dictionary_set_string(message, SQRLTargetBundleURLKey, currentApplication.bundleURL.absoluteString.UTF8String);
 	xpc_dictionary_set_string(message, SQRLUpdateBundleURLKey, updateBundle.bundleURL.absoluteString.UTF8String);
-	xpc_dictionary_set_string(message, SQRLBackupURLKey, self.applicationSupportURL.absoluteString.UTF8String);
 	xpc_dictionary_set_bool(message, SQRLShouldRelaunchKey, self.shouldRelaunch);
 	xpc_dictionary_set_bool(message, SQRLWaitForConnectionKey, true);
 	xpc_dictionary_set_data(message, SQRLCodeSigningRequirementKey, requirementData.bytes, requirementData.length);

--- a/Squirrel/ShipIt-main.m
+++ b/Squirrel/ShipIt-main.m
@@ -38,8 +38,7 @@ static NSString *NSStringFromXPCObject(xpc_object_t object) {
 static SQRLInstallationHandler prepareInstallation(xpc_object_t event) {
 	NSURL *targetBundleURL = [[NSURL URLWithString:@(xpc_dictionary_get_string(event, SQRLTargetBundleURLKey))] filePathURL];
 	NSURL *updateBundleURL = [[NSURL URLWithString:@(xpc_dictionary_get_string(event, SQRLUpdateBundleURLKey))] filePathURL];
-	NSURL *backupURL = [[NSURL URLWithString:@(xpc_dictionary_get_string(event, SQRLBackupURLKey))] filePathURL];
-	if (targetBundleURL == nil || updateBundleURL == nil || backupURL == nil) return nil;
+	if (targetBundleURL == nil || updateBundleURL == nil) return nil;
 
 	size_t requirementDataLen = 0;
 	const void *requirementDataPtr = xpc_dictionary_get_data(event, SQRLCodeSigningRequirementKey, &requirementDataLen);
@@ -54,7 +53,7 @@ static SQRLInstallationHandler prepareInstallation(xpc_object_t event) {
 			xpc_transaction_end();
 		};
 
-		SQRLInstaller *installer = [[SQRLInstaller alloc] initWithTargetBundleURL:targetBundleURL updateBundleURL:updateBundleURL backupURL:backupURL requirementData:requirementData];
+		SQRLInstaller *installer = [[SQRLInstaller alloc] initWithTargetBundleURL:targetBundleURL updateBundleURL:updateBundleURL requirementData:requirementData];
 
 		NSLog(@"Beginning installation");
 

--- a/SquirrelTests/SQRLInstallerSpec.m
+++ b/SquirrelTests/SQRLInstallerSpec.m
@@ -23,7 +23,6 @@ beforeEach(^{
 
 	xpc_dictionary_set_string(message, SQRLTargetBundleURLKey, self.testApplicationURL.absoluteString.UTF8String);
 	xpc_dictionary_set_string(message, SQRLUpdateBundleURLKey, updateURL.absoluteString.UTF8String);
-	xpc_dictionary_set_string(message, SQRLBackupURLKey, self.temporaryDirectoryURL.absoluteString.UTF8String);
 	xpc_dictionary_set_bool(message, SQRLShouldRelaunchKey, false);
 	xpc_dictionary_set_bool(message, SQRLWaitForConnectionKey, false);
 
@@ -72,23 +71,6 @@ it(@"should install an update from another volume", ^{
 	__block BOOL installed = NO;
 
 	xpc_dictionary_set_string(message, SQRLUpdateBundleURLKey, updateURL.absoluteString.UTF8String);
-	xpc_connection_send_message_with_reply(shipitConnection, message, dispatch_get_main_queue(), ^(xpc_object_t event) {
-		expect(xpc_dictionary_get_bool(event, SQRLShipItSuccessKey)).to.beTruthy();
-		expect([self errorFromObject:event]).to.beNil();
-
-		installed = YES;
-	});
-
-	expect(installed).will.beTruthy();
-	expect(self.testApplicationBundleVersion).will.equal(SQRLTestApplicationUpdatedShortVersionString);
-});
-
-it(@"should back up to another volume while updating", ^{
-	NSURL *diskImageURL = [self createAndMountDiskImageNamed:@"TestApplication Backup" fromDirectory:nil];
-
-	__block BOOL installed = NO;
-
-	xpc_dictionary_set_string(message, SQRLBackupURLKey, diskImageURL.absoluteString.UTF8String);
 	xpc_connection_send_message_with_reply(shipitConnection, message, dispatch_get_main_queue(), ^(xpc_object_t event) {
 		expect(xpc_dictionary_get_bool(event, SQRLShipItSuccessKey)).to.beTruthy();
 		expect([self errorFromObject:event]).to.beNil();


### PR DESCRIPTION
Replaced with a temporary directory generated from within Squirrel.

Authored by @jonsterling. Fixes #15.
