### PR TITLE
Change `SQRLShipItState` read/write interface to accept a `RACSignal`

### DIFF
--- a/Squirrel/SQRLInstaller.m
+++ b/Squirrel/SQRLInstaller.m
@@ -285,7 +285,7 @@ typedef struct {
 		state.installerState = nextState.integerValue;
 		state.installationStateAttempt = 1;
 		return [[state
-			writeUsingDirectoryManager:self.directoryManager]
+			writeUsingURL:self.directoryManager.shipItStateURL]
 			// Automatically begin the next step.
 			concat:[self stepRepeatedly:step withState:state]];
 	}];
@@ -333,7 +333,7 @@ typedef struct {
 			// control to -backUpBundleAtURL:. Really, the flow
 			// here should be refactored so it doesn't matter.
 			state.backupBundleURL = backupBundleURL;
-			return [state writeUsingDirectoryManager:self.directoryManager];
+			return [state writeUsingURL:self.directoryManager.shipItStateURL];
 		}]
 		setNameWithFormat:@"%@ -backUpWithState: %@", self, state];
 }

--- a/Squirrel/SQRLShipItState.h
+++ b/Squirrel/SQRLShipItState.h
@@ -58,33 +58,32 @@ typedef enum : NSInteger {
 
 @class RACSignal;
 @class SQRLCodeSignature;
-@class SQRLDirectoryManager;
 
 // Encapsulates all the state needed by the ShipIt process.
 @interface SQRLShipItState : MTLModel
 
 // Reads a `SQRLShipItState` from disk, at the location specified by the given
-// directory manager.
+// URL signal.
 //
-// directoryManager - Used to find the state location on disk. This must not be
-//                    nil.
+// URLSignal - Determines the file location to read from, the signal should send
+//             an `NSURL` object then complete, or error. This must not be nil.
 //
 // Returns a signal which will synchronously send a `SQRLShipItState` then
 // complete, or error.
-+ (RACSignal *)readUsingDirectoryManager:(SQRLDirectoryManager *)directoryManager;
++ (RACSignal *)readUsingURL:(RACSignal *)URL;
 
 // Initializes the receiver with the arguments that will not change during
 // installation.
 - (id)initWithTargetBundleURL:(NSURL *)targetBundleURL updateBundleURL:(NSURL *)updateBundleURL bundleIdentifier:(NSString *)bundleIdentifier codeSignature:(SQRLCodeSignature *)codeSignature;
 
-// Writes the receiver to disk, at the location specified by the given directory
-// manager.
+// Writes the receiver to disk, at the location specified by the given URL
+// signal.
 //
-// directoryManager - Used to find the state location on disk. This must not be
-//                    nil.
+// URL - Determines the file location to write to. The signal should send an
+//       `NSURL` object then complete, or error. This must not be nil.
 //
 // Returns a signal which will synchronously complete or error.
-- (RACSignal *)writeUsingDirectoryManager:(SQRLDirectoryManager *)directoryManager;
+- (RACSignal *)writeUsingURL:(RACSignal *)URL;
 
 // The URL to the app bundle that should be replaced with an update.
 @property (nonatomic, copy, readonly) NSURL *targetBundleURL;

--- a/Squirrel/SQRLShipItState.m
+++ b/Squirrel/SQRLShipItState.m
@@ -7,7 +7,6 @@
 //
 
 #import "SQRLShipItState.h"
-#import "SQRLDirectoryManager.h"
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 NSString * const SQRLShipItStateErrorDomain = @"SQRLShipItStateErrorDomain";
@@ -58,11 +57,10 @@ const NSInteger SQRLShipItStateErrorArchiving = 3;
 
 #pragma mark Serialization
 
-+ (RACSignal *)readUsingDirectoryManager:(SQRLDirectoryManager *)directoryManager {
-	NSParameterAssert(directoryManager != nil);
++ (RACSignal *)readUsingURL:(RACSignal *)URL {
+	NSParameterAssert(URL != nil);
 
-	return [[[[directoryManager
-		shipItStateURL]
+	return [[[URL
 		flattenMap:^(NSURL *stateURL) {
 			NSError *error = nil;
 			NSData *data = [NSData dataWithContentsOfURL:stateURL options:NSDataReadingUncached error:&error];
@@ -85,11 +83,11 @@ const NSInteger SQRLShipItStateErrorArchiving = 3;
 
 			return [RACSignal return:state];
 		}]
-		setNameWithFormat:@"+readUsingDirectoryManager: %@", directoryManager];
+		setNameWithFormat:@"+readUsingURL: %@", URL];
 }
 
-- (RACSignal *)writeUsingDirectoryManager:(SQRLDirectoryManager *)directoryManager {
-	NSParameterAssert(directoryManager != nil);
+- (RACSignal *)writeUsingURL:(RACSignal *)URL {
+	NSParameterAssert(URL != nil);
 
 	RACSignal *serialization = [RACSignal defer:^{
 		NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self];
@@ -107,7 +105,7 @@ const NSInteger SQRLShipItStateErrorArchiving = 3;
 
 	return [[[RACSignal
 		zip:@[
-			[directoryManager shipItStateURL],
+			URL,
 			serialization
 		] reduce:^(NSURL *stateURL, NSData *data) {
 			NSError *error = nil;
@@ -118,7 +116,7 @@ const NSInteger SQRLShipItStateErrorArchiving = 3;
 			return [RACSignal empty];
 		}]
 		flatten]
-		setNameWithFormat:@"%@ -writeUsingDirectoryManager: %@", self, directoryManager];
+		setNameWithFormat:@"%@ -writeUsingURL: %@", self, URL];
 }
 
 @end

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -410,8 +410,9 @@ const NSInteger SQRLUpdaterErrorInvalidJSON = 6;
 	return [[[[RACSignal
 		defer:^{
 			SQRLDirectoryManager *directoryManager = [[SQRLDirectoryManager alloc] initWithApplicationIdentifier:SQRLShipItLauncher.shipItJobLabel];
+			RACSignal *stateLocation = directoryManager.shipItStateURL;
 			return [[[[SQRLShipItState
-				readUsingDirectoryManager:directoryManager]
+				readUsingURL:stateLocation]
 				catchTo:[RACSignal empty]]
 				flattenMap:^(SQRLShipItState *existingState) {
 					if (existingState.installerState != SQRLInstallerStateNothingToDo) {
@@ -430,7 +431,7 @@ const NSInteger SQRLUpdaterErrorInvalidJSON = 6;
 				then:^{
 					SQRLShipItState *state = [[SQRLShipItState alloc] initWithTargetBundleURL:NSRunningApplication.currentApplication.bundleURL updateBundleURL:update.bundle.bundleURL bundleIdentifier:NSRunningApplication.currentApplication.bundleIdentifier codeSignature:self.signature];
 					state.relaunchAfterInstallation = self.shouldRelaunch;
-					return [state writeUsingDirectoryManager:directoryManager];
+					return [state writeUsingURL:stateLocation];
 				}];
 		}]
 		then:^{

--- a/Squirrel/ShipIt-main.m
+++ b/Squirrel/ShipIt-main.m
@@ -53,16 +53,17 @@ int main(int argc, const char * argv[]) {
 
 		const char *jobLabel = argv[1];
 		SQRLDirectoryManager *directoryManager = [[SQRLDirectoryManager alloc] initWithApplicationIdentifier:@(jobLabel)];
+		RACSignal *stateLocation = directoryManager.shipItStateURL;
 
 		[[[[[[SQRLShipItState
-			readUsingDirectoryManager:directoryManager]
+			readUsingURL:stateLocation]
 			flattenMap:^(SQRLShipItState *state) {
 				return waitForTerminationIfNecessary(state);
 			}]
 			then:^{
 				// Read the latest state, in case it was modified by the
 				// controlling application in the meantime.
-				return [SQRLShipItState readUsingDirectoryManager:directoryManager];
+				return [SQRLShipItState readUsingURL:stateLocation];
 			}]
 			catch:^(NSError *error) {
 				NSLog(@"Error reading saved installer state: %@", error);
@@ -89,7 +90,7 @@ int main(int argc, const char * argv[]) {
 						}];
 				} else {
 					return [[[[[state
-						writeUsingDirectoryManager:directoryManager]
+						writeUsingURL:stateLocation]
 						initially:^{
 							if (freshInstall) {
 								NSLog(@"Beginning installation");

--- a/SquirrelTests/SQRLInstallerSpec.m
+++ b/SquirrelTests/SQRLInstallerSpec.m
@@ -22,7 +22,7 @@ beforeEach(^{
 
 it(@"should install an update", ^{
 	SQRLShipItState *state = [[SQRLShipItState alloc] initWithTargetBundleURL:self.testApplicationURL updateBundleURL:updateURL bundleIdentifier:nil codeSignature:self.testApplicationSignature];
-	expect([[state writeUsingDirectoryManager:self.shipItDirectoryManager] waitUntilCompleted:NULL]).to.beTruthy();
+	expect([[state writeUsingURL:self.shipItDirectoryManager.shipItStateURL] waitUntilCompleted:NULL]).to.beTruthy();
 
 	[self launchShipIt];
 
@@ -36,7 +36,7 @@ it(@"should install an update and relaunch", ^{
 
 	SQRLShipItState *state = [[SQRLShipItState alloc] initWithTargetBundleURL:self.testApplicationURL updateBundleURL:updateURL bundleIdentifier:nil codeSignature:self.testApplicationSignature];
 	state.relaunchAfterInstallation = YES;
-	expect([[state writeUsingDirectoryManager:self.shipItDirectoryManager] waitUntilCompleted:NULL]).to.beTruthy();
+	expect([[state writeUsingURL:self.shipItDirectoryManager.shipItStateURL] waitUntilCompleted:NULL]).to.beTruthy();
 
 	[self launchShipIt];
 
@@ -49,7 +49,7 @@ it(@"should install an update from another volume", ^{
 	updateURL = [diskImageURL URLByAppendingPathComponent:updateURL.lastPathComponent];
 
 	SQRLShipItState *state = [[SQRLShipItState alloc] initWithTargetBundleURL:self.testApplicationURL updateBundleURL:updateURL bundleIdentifier:nil codeSignature:self.testApplicationSignature];
-	expect([[state writeUsingDirectoryManager:self.shipItDirectoryManager] waitUntilCompleted:NULL]).to.beTruthy();
+	expect([[state writeUsingURL:self.shipItDirectoryManager.shipItStateURL] waitUntilCompleted:NULL]).to.beTruthy();
 
 	[self launchShipIt];
 
@@ -61,7 +61,7 @@ it(@"should install an update to another volume", ^{
 	NSURL *targetURL = [diskImageURL URLByAppendingPathComponent:self.testApplicationURL.lastPathComponent];
 
 	SQRLShipItState *state = [[SQRLShipItState alloc] initWithTargetBundleURL:targetURL updateBundleURL:updateURL bundleIdentifier:nil codeSignature:self.testApplicationSignature];
-	expect([[state writeUsingDirectoryManager:self.shipItDirectoryManager] waitUntilCompleted:NULL]).to.beTruthy();
+	expect([[state writeUsingURL:self.shipItDirectoryManager.shipItStateURL] waitUntilCompleted:NULL]).to.beTruthy();
 
 	[self launchShipIt];
 
@@ -91,7 +91,7 @@ it(@"should not install an update after too many attempts", ^{
 	state.backupBundleURL = backupURL;
 	state.installerState = SQRLInstallerStateInstalling;
 	state.installationStateAttempt = 4;
-	expect([[state writeUsingDirectoryManager:self.shipItDirectoryManager] waitUntilCompleted:NULL]).to.beTruthy();
+	expect([[state writeUsingURL:self.shipItDirectoryManager.shipItStateURL] waitUntilCompleted:NULL]).to.beTruthy();
 
 	[self launchShipIt];
 
@@ -113,7 +113,7 @@ describe(@"signal handling", ^{
 		targetURL = self.testApplicationURL;
 
 		SQRLShipItState *state = [[SQRLShipItState alloc] initWithTargetBundleURL:self.testApplicationURL updateBundleURL:updateURL bundleIdentifier:nil codeSignature:self.testApplicationSignature];
-		expect([[state writeUsingDirectoryManager:self.shipItDirectoryManager] waitUntilCompleted:NULL]).to.beTruthy();
+		expect([[state writeUsingURL:self.shipItDirectoryManager.shipItStateURL] waitUntilCompleted:NULL]).to.beTruthy();
 
 		[self launchShipIt];
 

--- a/SquirrelTests/SQRLShipItStateSpec.m
+++ b/SquirrelTests/SQRLShipItStateSpec.m
@@ -42,18 +42,18 @@ it(@"should copy", ^{
 
 it(@"should fail to read state when no file exists yet", ^{
 	NSError *error = nil;
-	BOOL success = [[SQRLShipItState readUsingDirectoryManager:directoryManager] waitUntilCompleted:&error];
+	BOOL success = [[SQRLShipItState readUsingURL:directoryManager.shipItStateURL] waitUntilCompleted:&error];
 	expect(success).to.beFalsy();
 	expect(error).notTo.beNil();
 });
 
 it(@"should write and read state", ^{
 	NSError *error = nil;
-	BOOL success = [[state writeUsingDirectoryManager:directoryManager] waitUntilCompleted:&error];
+	BOOL success = [[state writeUsingURL:directoryManager.shipItStateURL] waitUntilCompleted:&error];
 	expect(success).to.beTruthy();
 	expect(error).to.beNil();
 
-	SQRLShipItState *readState = [[SQRLShipItState readUsingDirectoryManager:directoryManager] firstOrDefault:nil success:&success error:&error];
+	SQRLShipItState *readState = [[SQRLShipItState readUsingURL:directoryManager.shipItStateURL] firstOrDefault:nil success:&success error:&error];
 	expect(success).to.beTruthy();
 	expect(error).to.beNil();
 


### PR DESCRIPTION
Instead of giving it the entire `SQRLDirectoryManager` this makes it clear at
the call site which URL the receiver is using.
