### PR TITLE
Fix regex for 10.9

### DIFF
--- a/SquirrelTests/NSProcessInfoExtensionsSpec.m
+++ b/SquirrelTests/NSProcessInfoExtensionsSpec.m
@@ -16,9 +16,9 @@ describe(@"-sqrl_operatingSystemShortVersionString", ^{
 		expect(versionString).notTo.beNil();
 	});
 
-	it(@"should follow major.minor(.patch) format", ^{
+	it(@"should follow major.minor.patch format", ^{
 		NSError *error = nil;
-		NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^([0-9]+)\\.([0-9]+)(\\.([0-9]+))?$" options:0 error:&error];
+		NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^[0-9]+(\\.[0-9]+)*$" options:0 error:&error];
 		expect(regex).notTo.beNil();
 		expect(error).to.beNil();
 


### PR DESCRIPTION
10.9 reports as just that, no bugfix component. This makes the bugfix suffix
option, presumably all forseeable OSes will be major.minor.
