### PR TITLE
Unlock the keychain before building

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -40,12 +40,31 @@ config ()
     #
     # Individual names can be quoted to avoid word splitting.
     : ${SCHEMES:=Squirrel}
+
+    # A source-able file with information about the Keychain, containing our
+    # code-signing certificate.
+    : ${KEYCHAIN_INFO:=/var/lib/jenkins/config/xcodekeychain}
     
     export XCWORKSPACE
     export XCODEPROJ
     export BOOTSTRAP
     export XCTOOL_OPTIONS
     export SCHEMES
+    export KEYCHAIN_INFO
+}
+
+##
+## Code Signing
+##
+
+unlock_keychain ()
+{
+    if [ -e "$KEYCHAIN_INFO" ]
+    then
+        # Unlock the keychain so the certificates it contains can be used for building.
+        . "$KEYCHAIN_INFO"
+        security unlock-keychain -p "$XCODE_KEYCHAIN_PASSWORD" "$XCODE_KEYCHAIN"
+    fi
 }
 
 ##
@@ -55,6 +74,7 @@ config ()
 main ()
 {
     config
+    unlock_keychain
 
     if [ -f "$BOOTSTRAP" ]
     then


### PR DESCRIPTION
This isn't necessary for most library projects, but Squirrel's tests involve a codesigned application, so we need to have a certificate accessible.

Keychain logic copied from GHfM's `cibuild` script.
