### PR TITLE
Update URLs to Mantle repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/ReactiveCocoa/ReactiveCocoa.git
 [submodule "External/Mantle"]
 	path = External/Mantle
-	url = https://github.com/github/Mantle.git
+	url = https://github.com/MantleFramework/Mantle.git
 [submodule "External/OHHTTPStubs"]
 	path = External/OHHTTPStubs
 	url = https://github.com/github/OHHTTPStubs

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ does not embed them itself.
 # Dependencies
 
 Squirrel depends on [ReactiveCocoa](http://github.com/ReactiveCocoa/ReactiveCocoa)
-and [Mantle](https://github.com/github/Mantle).
+and [Mantle](https://github.com/MantleFramework/Mantle).
 
 If your application is already using ReactiveCocoa, ensure it is using the same
 version as Squirrel.


### PR DESCRIPTION
This change isn’t strictly necessary due to automatic redirection, but let’s keep our links fresh.
