### PR TITLE
Add steps to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ updates installed are valid.
 
 # Adopting Squirrel
 
-1. Install xctool (`brew install xctool`)
-1. Run `script/bootstrap`
+1. Install xctool with `brew install xctool`
 1. Add the Squirrel repository as a git submodule
+1. Run `script/bootstrap` from within the submodule
 1. Add a reference to Squirrel.xcodeproj to your project
 1. Add Squirrel.framework as a target dependency
 1. Link Squirrel.framework and add it to a Copy Files build phase which copies


### PR DESCRIPTION
Squirrel wasn't building properly for me. I was getting errors like:

```
/Users/corey/github/Squirrel.Mac/External/ReactiveCocoa/ReactiveCocoaFramework/ReactiveCocoa/RACDynamicSequence.m:128:1: Method possibly missing a [super dealloc] call
```

I just needed to install `xctool` and run `script/bootstrap` but those steps weren't in the Readme. I'm not sure if `Adopting Squirrel` is the best place to add those, maybe adding a `Building Squirrel` section would be better. But I leave that up to people who know this stuff better than I do!
