### PR TITLE
Log when we can’t get the running application code signature

### DIFF
--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -165,8 +165,13 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 	NSError *error = nil;
 	_signature = [SQRLCodeSignature currentApplicationSignature:&error];
 	if (_signature == nil) {
+#if DEBUG
 		NSLog(@"Could not get code signature for running application, application updates are disabled: %@", error);
 		return nil;
+#else
+		NSDictionary *exceptionInfo = @{ NSUnderlyingErrorKey: error };
+		@throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Could not get code signature for running application" userInfo:exceptionInfo];
+#endif
 	}
 
 	BOOL updatesDisabled = (getenv("DISABLE_UPDATE_CHECK") != NULL);


### PR DESCRIPTION
Don’t crash.
