### PR TITLE
Don’t attempt to sign .cstemp files

### DIFF
--- a/script/deep-codesign
+++ b/script/deep-codesign
@@ -170,6 +170,7 @@ while paths_to_search.size > 0
 
 		Dir.foreach(search_path) do |current_directory_entry|
 			next if current_directory_entry.start_with?(".")
+			File.delete(File.join(search_path, current_directory_entry)) if current_directory_entry.end_with?(".cstemp")
 
 			target = match_path(File.join(search_path, current_directory_entry))
 			next if target.nil?


### PR DESCRIPTION
Fixes #134.

@paulcbetts notes that we could ~~also~~ instead add a `SIGINT` handler which cleans up the `.cstemp` files, which may be preferable. (However, I had already written this :stuck_out_tongue_closed_eyes:)
