### PR TITLE
Stop checking for updates after downloading one

### DIFF
--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -248,6 +248,7 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 					}]
 					doCompleted:^{
 						self.state = SQRLUpdaterStateAwaitingRelaunch;
+                        _checkForUpdatesCommand = nil;
 					}];
 			}]
 			finally:^{

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -248,7 +248,7 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 					}]
 					doCompleted:^{
 						self.state = SQRLUpdaterStateAwaitingRelaunch;
-                        _checkForUpdatesCommand = nil;
+						_checkForUpdatesCommand = nil;
 					}];
 			}]
 			finally:^{


### PR DESCRIPTION
Fixes #111 

There's still the issue where a user who almost never restarts the app might get an 'old' update if several updates were released while the app is open. Ideally, we'd compare `pub_date`s to see if the downloaded update should be replaced with a new one.