### PR TITLE
Separate the update available and install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,18 @@ To know when an update is ready to be installed, you can subscribe to the
 }];
 ```
 
-## Installing Updates on Demand
+## Installing Updates
 
-Once you've been notified of an available update, you may want to present an interface
-informing the user about the update and offers the ability to install and relaunch.
+While downloaded updates are automatically installed when your application
+terminates, if don't want to wait you can terminate manually the app to begin
+the installation process immediately.
+
+Once an [update available notification](#update-available-notifications) has
+been received, you may want to present an interface informing the user about
+the update and offering the ability to install and relaunch.
 
 To install a downloaded update and automatically relaunch afterward, subscribe to
-`relaunchToInstallUpdate` on `SQRLUpdater`:
+the `relaunchToInstallUpdate` signal on `SQRLUpdater`:
 
 ```objc
 [[self.updater relaunchToInstallUpdate] subscribeError:^(NSError *error) {

--- a/README.md
+++ b/README.md
@@ -116,15 +116,15 @@ To know when an update is ready to be installed, you can subscribe to the
 ## Installing Updates
 
 While downloaded updates are automatically installed when your application
-terminates, if don't want to wait you can terminate manually the app to begin
+terminates, if don't want to wait you can manually terminate the app to begin
 the installation process immediately.
 
 Once an [update available notification](#update-available-notifications) has
 been received, you may want to present an interface informing the user about
 the update and offering the ability to install and relaunch.
 
-To install a downloaded update and automatically relaunch afterward, subscribe to
-the `relaunchToInstallUpdate` signal on `SQRLUpdater`:
+To explicitly install a downloaded update and automatically relaunch afterward,
+subscribe to the `relaunchToInstallUpdate` signal on `SQRLUpdater`:
 
 ```objc
 [[self.updater relaunchToInstallUpdate] subscribeError:^(NSError *error) {

--- a/README.md
+++ b/README.md
@@ -113,12 +113,13 @@ To know when an update is ready to be installed, you can subscribe to the
 }];
 ```
 
-If you've been notified of an available update, and don't want to wait for it to
-be installed automatically, you can terminate the app to begin the installation
-process immediately.
+## Installing Updates on Demand
 
-If you want to install a downloaded update and automatically relaunch afterward,
-`SQRLUpdater` can do that:
+Once you've been notified of an available update, you may want to present an interface
+informing the user about the update and offers the ability to install and relaunch.
+
+To install a downloaded update and automatically relaunch afterward, subscribe to
+`relaunchToInstallUpdate` on `SQRLUpdater`:
 
 ```objc
 [[self.updater relaunchToInstallUpdate] subscribeError:^(NSError *error) {


### PR DESCRIPTION
Don’t present these in the same section to clarify that the install should be performed after an update has been received.