### PR TITLE
Fix pruning

### DIFF
--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -49,16 +49,6 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 // Sends completed or error.
 @property (nonatomic, strong, readonly) RACSignal *shipItLauncher;
 
-// Lazily removes outdated temporary directories (used for previous updates)
-// upon first subscription.
-//
-// Pruning directories while an update is pending or in progress will result in
-// undefined behavior.
-//
-// Sends each removed directory then completes, or errors, on an unspecified
-// thread.
-@property (nonatomic, strong, readonly) RACSignal *prunedUpdateDirectories;
-
 // Parses an update model from downloaded data.
 //
 // data - JSON data representing an update manifest. This must not be nil.
@@ -169,32 +159,6 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 	BOOL updatesDisabled = (getenv("DISABLE_UPDATE_CHECK") != NULL);
 	@weakify(self);
 
-	_prunedUpdateDirectories = [[[RACSignal
-		defer:^{
-			SQRLDirectoryManager *directoryManager = [[SQRLDirectoryManager alloc] initWithApplicationIdentifier:SQRLShipItLauncher.shipItJobLabel];
-			return [directoryManager applicationSupportURL];
-		}]
-		flattenMap:^(NSURL *appSupportURL) {
-			NSFileManager *manager = [[NSFileManager alloc] init];
-			NSDirectoryEnumerator *enumerator = [manager enumeratorAtURL:appSupportURL includingPropertiesForKeys:nil options:NSDirectoryEnumerationSkipsSubdirectoryDescendants errorHandler:^(NSURL *URL, NSError *error) {
-				NSLog(@"Error enumerating item %@ within directory %@: %@", URL, appSupportURL, error);
-				return YES;
-			}];
-
-			return [[enumerator.rac_sequence.signal
-				filter:^(NSURL *enumeratedURL) {
-					NSString *name = enumeratedURL.lastPathComponent;
-					return [name hasPrefix:SQRLUpdaterUniqueTemporaryDirectoryPrefix];
-				}]
-				doNext:^(NSURL *directoryURL) {
-					NSError *error = nil;
-					if (![manager removeItemAtURL:directoryURL error:&error]) {
-						NSLog(@"Error removing old update directory at %@: %@", directoryURL, error.sqrl_verboseDescription);
-					}
-				}];
-		}]
-		setNameWithFormat:@"%@ -prunedUpdateDirectories", self];
-
 	_checkForUpdatesCommand = [[RACCommand alloc] initWithEnabled:[RACSignal return:@(!updatesDisabled)] signalBlock:^(id _) {
 		@strongify(self);
 		NSParameterAssert(self.updateRequest != nil);
@@ -204,7 +168,8 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 		[request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
 
 		// Prune old updates before the first update check.
-		return [[[[[[[[self.prunedUpdateDirectories
+		return [[[[[[[[[self
+			pruneUpdateDirectories]
 			catch:^(NSError *error) {
 				NSLog(@"Error pruning old updates: %@", error);
 				return [RACSignal empty];
@@ -499,6 +464,42 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 			return directoryManager.shipItStateURL;
 		}]
 		setNameWithFormat:@"%@ -shipItStateURL", self];
+}
+
+/// Lazily removes outdated temporary directories (used for previous updates)
+/// upon subscription.
+///
+/// Pruning directories while an update is pending or in progress will result in
+/// undefined behavior.
+///
+/// Sends each removed directory then completes, or errors, on an unspecified
+/// thread.
+- (RACSignal *)pruneUpdateDirectories {
+	return [[[RACSignal
+		defer:^{
+			SQRLDirectoryManager *directoryManager = [[SQRLDirectoryManager alloc] initWithApplicationIdentifier:SQRLShipItLauncher.shipItJobLabel];
+			return [directoryManager applicationSupportURL];
+		}]
+		flattenMap:^(NSURL *appSupportURL) {
+			NSFileManager *manager = [[NSFileManager alloc] init];
+			NSDirectoryEnumerator *enumerator = [manager enumeratorAtURL:appSupportURL includingPropertiesForKeys:nil options:NSDirectoryEnumerationSkipsSubdirectoryDescendants errorHandler:^(NSURL *URL, NSError *error) {
+				NSLog(@"Error enumerating item %@ within directory %@: %@", URL, appSupportURL, error);
+				return YES;
+			}];
+
+			return [[enumerator.rac_sequence.signal
+				filter:^(NSURL *enumeratedURL) {
+					NSString *name = enumeratedURL.lastPathComponent;
+					return [name hasPrefix:SQRLUpdaterUniqueTemporaryDirectoryPrefix];
+				}]
+				doNext:^(NSURL *directoryURL) {
+					NSError *error = nil;
+					if (![manager removeItemAtURL:directoryURL error:&error]) {
+						NSLog(@"Error removing old update directory at %@: %@", directoryURL, error.sqrl_verboseDescription);
+					}
+				}];
+		}]
+		setNameWithFormat:@"%@ -prunedUpdateDirectories", self];
 }
 
 #pragma mark Installing Updates

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -169,7 +169,7 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 	BOOL updatesDisabled = (getenv("DISABLE_UPDATE_CHECK") != NULL);
 	@weakify(self);
 
-	_prunedUpdateDirectories = [[[[RACSignal
+	_prunedUpdateDirectories = [[[RACSignal
 		defer:^{
 			SQRLDirectoryManager *directoryManager = [[SQRLDirectoryManager alloc] initWithApplicationIdentifier:SQRLShipItLauncher.shipItJobLabel];
 			return [directoryManager applicationSupportURL];
@@ -193,7 +193,6 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 					}
 				}];
 		}]
-		replayLazily]
 		setNameWithFormat:@"%@ -prunedUpdateDirectories", self];
 
 	_checkForUpdatesCommand = [[RACCommand alloc] initWithEnabled:[RACSignal return:@(!updatesDisabled)] signalBlock:^(id _) {

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -179,6 +179,7 @@ describe(@"updating", ^{
 			writeUpdate(update);
 
 			NSRunningApplication *app = launchWithEnvironment(nil);
+			expect([updateDirectoryURLs toArray]).toEventuallyNot(equal(@[]));
 			expect(@(app.terminated)).withTimeout(5).toEventually(beTruthy());
 			expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
 

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -178,7 +178,7 @@ describe(@"updating", ^{
 
 			writeUpdate(update);
 
-			NSRunningApplication *app = launchWithEnvironment(nil);
+			NSRunningApplication *app = launchWithEnvironment(@{ @"SQRLUpdateRequestCount": @2 });
 			expect([updateDirectoryURLs toArray]).toEventuallyNot(equal(@[]));
 			expect(@(app.terminated)).withTimeout(5).toEventually(beTruthy());
 			expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));

--- a/TestApplication/TestAppDelegate.m
+++ b/TestApplication/TestAppDelegate.m
@@ -72,6 +72,8 @@
 
 	__block NSUInteger updateCheckCount = 1;
 
+	NSInteger updateRequestCount = [NSProcessInfo.processInfo.environment[@"SQRLUpdateRequestCount"] integerValue];
+
 	[[[[[[[[[[RACSignal
 		defer:^{
 			NSLog(@"***** UPDATE CHECK %lu *****", (unsigned long)updateCheckCount);
@@ -90,7 +92,7 @@
 
 			return testUpdate.final;
 		}]
-		take:1]
+		take:updateRequestCount]
 		doNext:^(id _) {
 			NSLog(@"***** READY TO INSTALL UPDATE *****");
 		}]


### PR DESCRIPTION
Because we replay, we don’t ever prune after the first subscription. We just keep replaying the previous results. So we end up accumulating a ton of updates.

Fixes https://github.com/atom/atom/issues/7061.