### PR TITLE
Fix parsing of ISO 8601 dates

### DIFF
--- a/Squirrel/SQRLUpdate.m
+++ b/Squirrel/SQRLUpdate.m
@@ -74,7 +74,7 @@ NSString * const SQRLUpdateJSONPublicationDateKey = @"pub_date";
 
 + (NSValueTransformer *)releaseDateJSONTransformer {
 	// ISO 8601 Time Zone with ':'
-	NSString * const ISO8601DateFormat = @"yyyy'-'MM'-'DD'T'HH':'mm':'ssZZZZZ";
+	NSString * const ISO8601DateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ssZZZZZ";
 
 	return [MTLValueTransformer reversibleTransformerWithForwardBlock:^ NSDate * (NSString *dateString) {
 		if (![dateString isKindOfClass:NSString.class]) return nil;

--- a/SquirrelTests/SQRLUpdateSpec.m
+++ b/SquirrelTests/SQRLUpdateSpec.m
@@ -45,12 +45,12 @@ it(@"should validate release name and notes", ^{
 
 it(@"should parse Central style dates", ^{
 	SQRLUpdate *update = [MTLJSONAdapter modelOfClass:SQRLUpdate.class fromJSONDictionary:@{ @"url": @"http://example.com/update", @"pub_date": @"Tue Sep 17 10:24:27 -0700 2013" } error:NULL];
-	expect(update.releaseDate).notTo(beNil());
+	expect(update.releaseDate).to(equal([NSDate dateWithTimeIntervalSince1970:1379438667]));
 });
 
 it(@"should parse ISO 8601 dates", ^{
 	SQRLUpdate *update = [MTLJSONAdapter modelOfClass:SQRLUpdate.class fromJSONDictionary:@{ @"url": @"http://example.com/update", @"pub_date": @"2013-09-18T13:17:07+01:00" } error:NULL];
-	expect(update.releaseDate).notTo(beNil());
+	expect(update.releaseDate).to(equal([NSDate dateWithTimeIntervalSince1970:1379506627]));
 });
 
 QuickSpecEnd


### PR DESCRIPTION
`DD` is day of year; `dd` is day of month.