### PR TITLE
Error if there's an update available but the app's on a read-only volume

### DIFF
--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -33,6 +33,9 @@ const NSInteger SQRLUpdaterErrorInvalidServerResponse = 5;
 const NSInteger SQRLUpdaterErrorInvalidJSON = 6;
 const NSInteger SQRLUpdaterErrorInvalidServerBody = 7;
 
+/// The application's being run on a read-only volume.
+const NSInteger SQRLUpdaterErrorReadOnlyVolume = 7;
+
 // The prefix used when creating temporary directories for updates. This will be
 // followed by a random string of characters.
 static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
@@ -174,7 +177,12 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 
 		BOOL readOnlyVolume = [self isRunningOnReadOnlyVolume];
 		if (readOnlyVolume) {
-			return [RACSignal empty];
+			NSDictionary *errorInfo = @{
+				NSLocalizedDescriptionKey: NSLocalizedString(@"Read-only volume", nil),
+				NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"The application is on a read-only volume. Please move the application and try again. If you're on macOS Sierra or later, you'll need to move the application out of the Downloads directory. See https://github.com/Squirrel/Squirrel.Mac/issues/182 for more information.", nil),
+			};
+			NSError *error = [NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorReadOnlyVolume userInfo:errorInfo];
+			return [RACSignal error:error];
 		}
 
 		return [[[[[[[[self

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -175,16 +175,6 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 		NSMutableURLRequest *request = [self.updateRequest mutableCopy];
 		[request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
 
-		BOOL readOnlyVolume = [self isRunningOnReadOnlyVolume];
-		if (readOnlyVolume) {
-			NSDictionary *errorInfo = @{
-				NSLocalizedDescriptionKey: NSLocalizedString(@"Read-only volume", nil),
-				NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"The application is on a read-only volume. Please move the application and try again. If you're on macOS Sierra or later, you'll need to move the application out of the Downloads directory. See https://github.com/Squirrel/Squirrel.Mac/issues/182 for more information.", nil),
-			};
-			NSError *error = [NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorReadOnlyVolume userInfo:errorInfo];
-			return [RACSignal error:error];
-		}
-
 		return [[[[[[[[self
 			performHousekeeping]
 			then:^{
@@ -207,6 +197,16 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 
 					if (httpResponse.statusCode == 204 /* No Content */) {
 						return [RACSignal empty];
+					}
+
+					BOOL readOnlyVolume = [self isRunningOnReadOnlyVolume];
+					if (readOnlyVolume) {
+						NSDictionary *errorInfo = @{
+						NSLocalizedDescriptionKey: NSLocalizedString(@"Read-only volume", nil),
+						NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"The application is on a read-only volume. Please move the application and try again. If you're on macOS Sierra or later, you'll need to move the application out of the Downloads directory. See https://github.com/Squirrel/Squirrel.Mac/issues/182 for more information.", nil),
+						};
+						NSError *error = [NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorReadOnlyVolume userInfo:errorInfo];
+						return [RACSignal error:error];
 					}
 				}
 

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -34,7 +34,7 @@ const NSInteger SQRLUpdaterErrorInvalidJSON = 6;
 const NSInteger SQRLUpdaterErrorInvalidServerBody = 7;
 
 /// The application's being run on a read-only volume.
-const NSInteger SQRLUpdaterErrorReadOnlyVolume = 7;
+const NSInteger SQRLUpdaterErrorReadOnlyVolume = 8;
 
 // The prefix used when creating temporary directories for updates. This will be
 // followed by a random string of characters.

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -172,6 +172,11 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 		NSMutableURLRequest *request = [self.updateRequest mutableCopy];
 		[request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
 
+		BOOL readOnlyVolume = [self isRunningOnReadOnlyVolume];
+		if (readOnlyVolume) {
+			return [RACSignal empty];
+		}
+
 		return [[[[[[[[self
 			performHousekeeping]
 			then:^{

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -20,6 +20,7 @@
 #import "SQRLShipItRequest.h"
 #import <ReactiveCocoa/EXTScope.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
+#import <sys/mount.h>
 
 NSString * const SQRLUpdaterErrorDomain = @"SQRLUpdaterErrorDomain";
 NSString * const SQRLUpdaterServerDataErrorKey = @"SQRLUpdaterServerDataErrorKey";
@@ -490,6 +491,14 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 			return directoryManager.shipItStateURL;
 		}]
 		setNameWithFormat:@"%@ -shipItStateURL", self];
+}
+
+/// Is the host app running on a read-only volume?
+- (BOOL)isRunningOnReadOnlyVolume {
+	struct statfs statfsInfo;
+	NSURL *bundleURL = NSRunningApplication.currentApplication.bundleURL;
+	statfs(bundleURL.fileSystemRepresentation, &statfsInfo);
+	return (statfsInfo.f_flags & MNT_RDONLY) != 0;
 }
 
 - (RACSignal *)performHousekeeping {

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -510,8 +510,13 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 - (BOOL)isRunningOnReadOnlyVolume {
 	struct statfs statfsInfo;
 	NSURL *bundleURL = NSRunningApplication.currentApplication.bundleURL;
-	statfs(bundleURL.fileSystemRepresentation, &statfsInfo);
-	return (statfsInfo.f_flags & MNT_RDONLY) != 0;
+	int result = statfs(bundleURL.fileSystemRepresentation, &statfsInfo);
+	if (result == 0) {
+		return (statfsInfo.f_flags & MNT_RDONLY) != 0;
+	} else {
+		// If we can't even check if the volume is read-only, assume it is.
+		return true;
+	}
 }
 
 - (RACSignal *)performHousekeeping {

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -202,7 +202,7 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 					BOOL readOnlyVolume = [self isRunningOnReadOnlyVolume];
 					if (readOnlyVolume) {
 						NSDictionary *errorInfo = @{
-						NSLocalizedDescriptionKey: NSLocalizedString(@"Read-only volume", nil),
+						NSLocalizedDescriptionKey: NSLocalizedString(@"Cannot update while running on a read-only volume", nil),
 						NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"The application is on a read-only volume. Please move the application and try again. If you're on macOS Sierra or later, you'll need to move the application out of the Downloads directory. See https://github.com/Squirrel/Squirrel.Mac/issues/182 for more information.", nil),
 						};
 						NSError *error = [NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorReadOnlyVolume userInfo:errorInfo];


### PR DESCRIPTION
Addresses #182

I _think_ it makes sense to only error once we know that it matters, i.e., that there's an update available. Otherwise it'd just be an annoying error when the user first downloads the app.

The read-only volume check is taken from Sparkle: https://github.com/sparkle-project/Sparkle/blob/3a5c620b60f483b71f8c28573ac29bf85fda6193/Sparkle/SUHost.m#L178-L183