### PR TITLE
Add auth headers to zip download requests not just feed requests.

### DIFF
--- a/Squirrel/SQRLUpdater.h
+++ b/Squirrel/SQRLUpdater.h
@@ -24,7 +24,7 @@ typedef enum : NSUInteger {
 } SQRLUpdaterState;
 
 // Block for providing download requests given a download url
-typedef NSURLRequest * (^RequestForDownload)(NSURL *);
+typedef NSURLRequest * (^SQRLRequestForDownload)(NSURL *);
 
 // The domain for errors originating within SQRLUpdater.
 extern NSString * const SQRLUpdaterErrorDomain;
@@ -102,7 +102,7 @@ extern NSString * const SQRLUpdaterJSONObjectErrorKey;
 //
 // If initialized with -initWithUpdateRequest: this block will
 // return a generic NSURLRequest with the provided url.
-@property (nonatomic, copy) RequestForDownload requestForDownload;
+@property (nonatomic, copy) SQRLRequestForDownload requestForDownload;
 
 // The `SQRLUpdate` subclass to instantiate with the server's response.
 //
@@ -133,7 +133,7 @@ extern NSString * const SQRLUpdaterJSONObjectErrorKey;
 //                      updateRequest param.
 //
 // Returns the initialized `SQRLUpdater`.
-- (id)initWithUpdateRequest:(NSURLRequest *)updateRequest requestForDownload:(RequestForDownload)requestForDownload;
+- (id)initWithUpdateRequest:(NSURLRequest *)updateRequest requestForDownload:(SQRLRequestForDownload)requestForDownload;
 
 // Executes `checkForUpdatesCommand` (if enabled) every `interval` seconds.
 //

--- a/Squirrel/SQRLUpdater.h
+++ b/Squirrel/SQRLUpdater.h
@@ -23,6 +23,9 @@ typedef enum : NSUInteger {
        SQRLUpdaterStateAwaitingRelaunch,
 } SQRLUpdaterState;
 
+// Block for providing download requests given a download url
+typedef NSURLRequest * (^RequestForDownload)(NSURL *);
+
 // The domain for errors originating within SQRLUpdater.
 extern NSString * const SQRLUpdaterErrorDomain;
 
@@ -92,6 +95,15 @@ extern NSString * const SQRLUpdaterJSONObjectErrorKey;
 // This property must never be set to nil.
 @property (atomic, copy) NSURLRequest *updateRequest;
 
+// The block used for fetching a given download request
+//
+// The default value is the argument that was originally passed to
+// -initWithUpdateRequest:requestForDownload:.
+//
+// If initialized with -initWithUpdateRequest: this block will
+// return a generic NSURLRequest with the provided url.
+@property (nonatomic, copy) RequestForDownload requestForDownload;
+
 // The `SQRLUpdate` subclass to instantiate with the server's response.
 //
 // By default, this is `SQRLUpdate` itself, but it can be set to a custom
@@ -110,6 +122,18 @@ extern NSString * const SQRLUpdaterJSONObjectErrorKey;
 //
 // Returns the initialized `SQRLUpdater`.
 - (id)initWithUpdateRequest:(NSURLRequest *)updateRequest;
+
+// Initializes an updater that will send the given request to check for updates
+// and passes a block to provide requests for the update downloads.
+//
+// updateRequest - Same as with initWithUpdateRequest
+// requestForDownload - Once the update url is found for the update download, allow
+//                      providing custom requests that can be costomized as desired.
+//                      Useful for including `Authorization` headers just like the
+//                      updateRequest param.
+//
+// Returns the initialized `SQRLUpdater`.
+- (id)initWithUpdateRequest:(NSURLRequest *)updateRequest requestForDownload:(RequestForDownload)requestForDownload;
 
 // Executes `checkForUpdatesCommand` (if enabled) every `interval` seconds.
 //

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -388,6 +388,11 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 			if (self.etag != nil) {
 				[zipDownloadRequest setValue:self.etag forHTTPHeaderField:@"If-None-Match"];
 			}
+			// Add auth headers from initial request, so that file downloads get authenticated
+			NSDictionary *HTTPHeaders = self.updateRequest.allHTTPHeaderFields;
+			for (NSString *headerField in HTTPHeaders) {
+				[zipDownloadRequest setValue:HTTPHeaders[headerField] forHTTPHeaderField:headerField];
+			}
 
 			return [[[NSURLConnection
 				rac_sendAsynchronousRequest:zipDownloadRequest]

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -384,14 +384,16 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 		defer:^{
 			NSURL *zipDownloadURL = update.updateURL;
 			NSMutableURLRequest *zipDownloadRequest = [NSMutableURLRequest requestWithURL:zipDownloadURL];
-			[zipDownloadRequest setValue:@"application/zip" forHTTPHeaderField:@"Accept"];
-			if (self.etag != nil) {
-				[zipDownloadRequest setValue:self.etag forHTTPHeaderField:@"If-None-Match"];
-			}
+
 			// Add auth headers from initial request, so that file downloads get authenticated
 			NSDictionary *HTTPHeaders = self.updateRequest.allHTTPHeaderFields;
 			for (NSString *headerField in HTTPHeaders) {
 				[zipDownloadRequest setValue:HTTPHeaders[headerField] forHTTPHeaderField:headerField];
+			}
+
+			[zipDownloadRequest setValue:@"application/zip" forHTTPHeaderField:@"Accept"];
+			if (self.etag != nil) {
+				[zipDownloadRequest setValue:self.etag forHTTPHeaderField:@"If-None-Match"];
 			}
 
 			return [[[NSURLConnection

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -149,7 +149,7 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 	}];
 }
 
-- (id)initWithUpdateRequest:(NSURLRequest *)updateRequest requestForDownload:(RequestForDownload)requestForDownload {
+- (id)initWithUpdateRequest:(NSURLRequest *)updateRequest requestForDownload:(SQRLRequestForDownload)requestForDownload {
 	NSParameterAssert(updateRequest != nil);
 	NSParameterAssert(requestForDownload != nil);
 


### PR DESCRIPTION
Our server checks the auth not just for checking the feed but also actually downloading the zip. It would be helpful if we could set headers on those requests as well.