### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ and Mantle.framework are copied into.
 Once Squirrel is added to your project, you need to configure and start it.
 
 ```objc
-#import <Squirrel/Squirrel.h>
+# import <Squirrel/Squirrel.h>
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
 	NSURLComponents *components = [[NSURLComponents alloc] init];


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
