### PR TITLE
fix: link ShipIt to ReactiveCocoa and Mantle correctly

### DIFF
--- a/Squirrel.xcodeproj/project.pbxproj
+++ b/Squirrel.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		30D4F8B6224575BE0013B080 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909A18E46DFE00786EFE /* ReactiveCocoa.framework */; };
+		30D4F8B7224575ED0013B080 /* Mantle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909818E46DE900786EFE /* Mantle.framework */; };
 		533076EB17EB688300BDCCE0 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D097B9BC17BB4777006C3FEB /* IOKit.framework */; };
 		534FF35B17D8E8B90020A51A /* unused-helper in Copy LoginItems */ = {isa = PBXBuildFile; fileRef = D0B1DDCB17B487D90059C355 /* unused-helper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		534FF36117D8E90A0020A51A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F60CA7EA179FC4F60069F69A /* Foundation.framework */; };
@@ -457,6 +459,8 @@
 				D014AC1F17B979C4007D79D0 /* Cocoa.framework in Frameworks */,
 				D014AC1D17B979B7007D79D0 /* Security.framework in Frameworks */,
 				D014AC1E17B979BD007D79D0 /* ServiceManagement.framework in Frameworks */,
+				30D4F8B6224575BE0013B080 /* ReactiveCocoa.framework in Frameworks */,
+				30D4F8B7224575ED0013B080 /* Mantle.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/script/cibuild
+++ b/script/cibuild
@@ -112,7 +112,7 @@ build_scheme ()
     echo "*** Building Squirrel..."
     echo
 
-    xcodebuild -scheme Squirrel -workspace Squirrel.xcworkspace build >/dev/null || exit $?
+    xcodebuild -scheme Squirrel -workspace Squirrel.xcworkspace build -configuration Release >/dev/null || exit $?
 }
 
 export -f build_scheme


### PR DESCRIPTION
This PR does two things

* (a) Ensures that the `ShipIt` binary is correctly linked to `ReactiveCocoa` and `Mantle` (it wasn't before and we have a _suspicion_ that this is causing really weird duplicate symbol errors on some devices)
* (b) Ensures that `cibuild` runs the `Release` config because the last thing we shipped I'm pretty sure was a debug build 🤷‍♂️ 