### PR TITLE
chore: fix missing deallocs, deprecation warnings and invalid casts

### DIFF
--- a/Squirrel/SQRLInstaller.m
+++ b/Squirrel/SQRLInstaller.m
@@ -517,7 +517,7 @@ NSString * const SQRLInstallerOwnedBundleKey = @"SQRLInstallerOwnedBundle";
 		setNameWithFormat:@"%@ -installItemAtURL: %@ fromURL: %@", self, targetURL, sourceURL];
 }
 
-#pragma Quarantine Bit Removal
+#pragma mark Quarantine Bit Removal
 
 - (RACSignal *)clearQuarantineForDirectory:(NSURL *)directory {
 	NSParameterAssert(directory != nil);

--- a/Squirrel/SQRLShipItLauncher.m
+++ b/Squirrel/SQRLShipItLauncher.m
@@ -127,6 +127,9 @@ const NSInteger SQRLShipItLauncherErrorCouldNotStartService = 1;
 		setNameWithFormat:@"+shipItAuthorization"];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 + (RACSignal *)launchPrivileged:(BOOL)privileged {
 	return [[[RACSignal
 		zip:@[
@@ -156,5 +159,7 @@ const NSInteger SQRLShipItLauncherErrorCouldNotStartService = 1;
 		flatten]
 		setNameWithFormat:@"+launchPrivileged: %i", (int)privileged];
 }
+
+#pragma clang diagnostic pop
 
 @end

--- a/Squirrel/SQRLZipArchiver.m
+++ b/Squirrel/SQRLZipArchiver.m
@@ -54,7 +54,7 @@ const NSInteger SQRLZipArchiverShellTaskFailed = 1;
 
 	_dittoTask = [[NSTask alloc] init];
 	_dittoTask.launchPath = @"/usr/bin/ditto";
-	_dittoTask.environment = @{ @"DITTOABORT": @1 };
+	_dittoTask.environment = @{ @"DITTOABORT": @"1" };
 	_dittoTask.standardError = self.standardErrorPipe;
 
 	@weakify(self);


### PR DESCRIPTION
Found while building with Chromiums config.  Couple of missing `super dealloc` calls, an invalid literal cast and some deprecation warnings which we can't do anything about so let's just suppress them