### PR TITLE
fix: use new ShipIt binary on macOS 11.0 to workaround flaw in launchApplicationAtURL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode8.3
+osx_image: xcode9.4
 language: objective-c
 
 install: script/bootstrap

--- a/script/cibuild
+++ b/script/cibuild
@@ -112,7 +112,7 @@ build_scheme ()
     echo "*** Building Squirrel..."
     echo
 
-    xcodebuild -scheme Squirrel -workspace Squirrel.xcworkspace build
+    xcodebuild -scheme Squirrel -workspace Squirrel.xcworkspace build >/dev/null || exit $?
 }
 
 export -f build_scheme

--- a/script/cibuild
+++ b/script/cibuild
@@ -112,7 +112,7 @@ build_scheme ()
     echo "*** Building Squirrel..."
     echo
 
-    xcodebuild -scheme Squirrel -workspace Squirrel.xcworkspace build >/dev/null || exit $?
+    xcodebuild -scheme Squirrel -workspace Squirrel.xcworkspace build
 }
 
 export -f build_scheme


### PR DESCRIPTION
It looks like `launchApplicationAtURL` doesn't work in background tasks on Big Sur (nor do any of the 4 alternative APIs).  This works around an issue where the updated app wouldn't launch on 11.0 after the update.  This issue has been reported to apple and we hope to remove this workaround soon.