### PR TITLE
align terminationHandler with dealloc in SQRLZipArchiver

### DIFF
--- a/Squirrel/SQRLZipArchiver.m
+++ b/Squirrel/SQRLZipArchiver.m
@@ -63,6 +63,7 @@ const NSInteger SQRLZipArchiverShellTaskFailed = 1;
 		if (self == nil) return;
 
 		[self->_taskTerminated sendNext:@(task.terminationStatus)];
+		[self.standardErrorPipe.fileHandleForReading closeFile];
 	};
 
 	RACSubject *errorDataChunks = [[RACSubject subject] setNameWithFormat:@"errorDataChunks"];


### PR DESCRIPTION
For some reason even though the `NSTask` is terminated the file handle is still being read.  Fixes #247

Verified locally using the electron test suite and `chown nobody:nogroup Electron.app` during the test suite