### PR TITLE
build: align Mantle and ReactiveObjC with Electron's pinned versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
             DEVELOPMENT_TEAM= \
             ONLY_ACTIVE_ARCH=YES \
             VALID_ARCHS="arm64 x86_64" \
+            OTHER_CODE_SIGN_FLAGS=--timestamp=none \
             | xcbeautify --renderer github-actions && exit ${PIPESTATUS[0]}
 
       - name: Test

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "Carthage.checkout/Nimble"]
 	path = Carthage/Checkouts/Nimble
 	url = https://github.com/Quick/Nimble.git
-[submodule "Carthage.checkout/ReactiveCocoa"]
-	path = Carthage/Checkouts/ReactiveCocoa
-	url = https://github.com/ReactiveCocoa/ReactiveCocoa.git
 [submodule "Carthage.checkout/Quick"]
 	path = Carthage/Checkouts/Quick
 	url = https://github.com/Quick/Quick.git
@@ -16,7 +13,6 @@
 [submodule "Carthage.checkout/Mantle"]
 	path = Carthage/Checkouts/Mantle
 	url = https://github.com/Mantle/Mantle.git
-[submodule "Carthage/Checkouts/Nimble"]
-	url = https://github.com/Quick/Nimble.git
-[submodule "Carthage/Checkouts/Quick"]
-	url = https://github.com/Quick/Quick.git
+[submodule "Carthage/Checkouts/ReactiveObjC"]
+	path = Carthage/Checkouts/ReactiveObjC
+	url = https://github.com/ReactiveCocoa/ReactiveObjC.git

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Mantle/Mantle" ~> 1.5.3
-github "ReactiveCocoa/ReactiveCocoa" ~> 2.4.3
+github "Mantle/Mantle" ~> 2.2
+github "ReactiveCocoa/ReactiveObjC" ~> 3.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
-github "Mantle/Mantle" "1.5.8"
+github "Mantle/Mantle" "2a8e2123a3931038179ee06105c9e6ec336b12ea"
 github "Quick/Nimble" "v9.2.1"
 github "Quick/Quick" "v5.0.1"
-github "ReactiveCocoa/ReactiveCocoa" "v2.5"
+github "ReactiveCocoa/ReactiveObjC" "74ab5baccc6f7202c8ac69a8d1e152c29dc1ea76"
 github "jspahrsummers/xcconfigs" "0.8.1"

--- a/Squirrel.xcodeproj/project.pbxproj
+++ b/Squirrel.xcodeproj/project.pbxproj
@@ -25,8 +25,6 @@
 		5397A69D187DF8610014A477 /* SQRLInstallerOwnedBundle.m in Sources */ = {isa = PBXBuildFile; fileRef = 5397A5EB187DA2570014A477 /* SQRLInstallerOwnedBundle.m */; };
 		53AACF4B17E9CA0500B41027 /* SQRLUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 53AACF4917E9CA0500B41027 /* SQRLUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		53AACF4C17E9CA0500B41027 /* SQRLUpdate.m in Sources */ = {isa = PBXBuildFile; fileRef = 53AACF4A17E9CA0500B41027 /* SQRLUpdate.m */; };
-		88CA21971BD980FC006693B7 /* MTLEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 88CA21941BD980FC006693B7 /* MTLEXTRuntimeExtensions.m */; };
-		88CA21981BD980FC006693B7 /* MTLEXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 88CA21961BD980FC006693B7 /* MTLEXTScope.m */; };
 		D000218F17BACEFF0050109A /* SQRLZipArchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = D000218D17BACEFF0050109A /* SQRLZipArchiver.m */; };
 		D000219717BAD34D0050109A /* TestApplication.app.zip in Resources */ = {isa = PBXBuildFile; fileRef = D000219617BAD34D0050109A /* TestApplication.app.zip */; };
 		D000219917BAD35C0050109A /* SQRLZipArchiverSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D000219817BAD35C0050109A /* SQRLZipArchiverSpec.m */; };
@@ -55,7 +53,6 @@
 		D06B58B518032B1500656D97 /* RACSignal+SQRLTransactionExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D06B58B318032B1500656D97 /* RACSignal+SQRLTransactionExtensions.m */; };
 		D06B58B618032B1500656D97 /* RACSignal+SQRLTransactionExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D06B58B318032B1500656D97 /* RACSignal+SQRLTransactionExtensions.m */; };
 		D06B58D118035B5A00656D97 /* SQRLTerminationListenerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D06B58D018035B5A00656D97 /* SQRLTerminationListenerSpec.m */; };
-		D06F7B101AD72DD30009A3BC /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = D06F7B0F1AD72DD30009A3BC /* RACKVOProxy.m */; };
 		D08D4E0D17B451500012B22D /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0C22BDA179CC00E00158214 /* Cocoa.framework */; };
 		D08D4E1317B451500012B22D /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D08D4E1117B451500012B22D /* InfoPlist.strings */; };
 		D08D4E1517B451500012B22D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D08D4E1417B451500012B22D /* main.m */; };
@@ -72,66 +69,11 @@
 		D0964B3D17F2E20B00D88BF7 /* NSBundle+SQRLVersionExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D0964B3B17F2E20B00D88BF7 /* NSBundle+SQRLVersionExtensions.m */; };
 		D0964B3E17F2E20B00D88BF7 /* NSBundle+SQRLVersionExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D0964B3B17F2E20B00D88BF7 /* NSBundle+SQRLVersionExtensions.m */; };
 		D097B9BD17BB4777006C3FEB /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D097B9BC17BB4777006C3FEB /* IOKit.framework */; };
-		D09C66291A00520B007D7ED0 /* NSArray+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C66281A00520B007D7ED0 /* NSArray+RACSequenceAdditions.m */; };
-		D09C662C1A005226007D7ED0 /* NSObject+RACKVOWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C662A1A005226007D7ED0 /* NSObject+RACKVOWrapper.m */; };
-		D09C662D1A005226007D7ED0 /* NSObject+RACPropertySubscribing.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C662B1A005226007D7ED0 /* NSObject+RACPropertySubscribing.m */; };
-		D09C66351A00535B007D7ED0 /* RACKVOTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C66341A00535B007D7ED0 /* RACKVOTrampoline.m */; };
-		D09C66381A00537A007D7ED0 /* NSObject+RACDeallocating.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C66361A00537A007D7ED0 /* NSObject+RACDeallocating.m */; };
-		D09C66391A00537A007D7ED0 /* NSObject+RACDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C66371A00537A007D7ED0 /* NSObject+RACDescription.m */; };
-		D09C663B1A00538D007D7ED0 /* RACObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C663A1A00538D007D7ED0 /* RACObjCRuntime.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		D09C663D1A0053C6007D7ED0 /* NSString+RACKeyPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C663C1A0053C6007D7ED0 /* NSString+RACKeyPathUtilities.m */; };
-		D09C663F1A005433007D7ED0 /* NSEnumerator+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C663E1A005433007D7ED0 /* NSEnumerator+RACSequenceAdditions.m */; };
-		D09C66411A005592007D7ED0 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C66401A005592007D7ED0 /* MTLModel+NSCoding.m */; };
-		D09C66461A0055E6007D7ED0 /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C66421A0055E6007D7ED0 /* NSArray+MTLManipulationAdditions.m */; };
-		D09C66471A0055E6007D7ED0 /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C66431A0055E6007D7ED0 /* NSDictionary+MTLManipulationAdditions.m */; };
-		D09C66481A0055E6007D7ED0 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C66441A0055E6007D7ED0 /* NSError+MTLModelException.m */; };
-		D09C66491A0055E6007D7ED0 /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C66451A0055E6007D7ED0 /* NSObject+MTLComparisonAdditions.m */; };
-		D09C664B1A0055F3007D7ED0 /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D09C664A1A0055F3007D7ED0 /* NSValueTransformer+MTLInversionAdditions.m */; };
+		E0A1D0102DB8C00100000010 /* Mantle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909818E46DE900786EFE /* Mantle.framework */; };
+		E0A1D0112DB8C00100000011 /* ReactiveObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909A18E46DFE00786EFE /* ReactiveObjC.framework */; };
 		D09D244117B595470001FAF8 /* SQRLInstallerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D09D244017B595470001FAF8 /* SQRLInstallerSpec.m */; };
 		D09D244A17B59AB30001FAF8 /* TestApplication 2.1.app in Resources */ = {isa = PBXBuildFile; fileRef = D09D244917B59AB30001FAF8 /* TestApplication 2.1.app */; };
 		D0A6D2BC17B9FA9E00B2C3DF /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6EB217F179D0E4D001108CF /* Security.framework */; };
-		D0AFE33B1A00282C00C6048F /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3381A00282C00C6048F /* MTLJSONAdapter.m */; };
-		D0AFE33C1A00282C00C6048F /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3391A00282C00C6048F /* MTLModel.m */; };
-		D0AFE33D1A00282C00C6048F /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE33A1A00282C00C6048F /* MTLValueTransformer.m */; };
-		D0AFE3431A00285000C6048F /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3411A00285000C6048F /* MTLReflection.m */; };
-		D0AFE3441A00285000C6048F /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3421A00285000C6048F /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; };
-		D0AFE34A1A00287100C6048F /* RACCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3451A00287100C6048F /* RACCommand.m */; };
-		D0AFE34B1A00287100C6048F /* RACDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3461A00287100C6048F /* RACDisposable.m */; };
-		D0AFE34C1A00287100C6048F /* RACScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3471A00287100C6048F /* RACScheduler.m */; };
-		D0AFE34D1A00287100C6048F /* RACSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3481A00287100C6048F /* RACSignal.m */; };
-		D0AFE34E1A00287100C6048F /* RACSignal+Operations.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3491A00287100C6048F /* RACSignal+Operations.m */; };
-		D0AFE3651A0028A400C6048F /* RACBlockTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE34F1A0028A400C6048F /* RACBlockTrampoline.m */; };
-		D0AFE3661A0028A400C6048F /* RACCompoundDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3501A0028A400C6048F /* RACCompoundDisposable.m */; };
-		D0AFE3671A0028A400C6048F /* RACDynamicSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3511A0028A400C6048F /* RACDynamicSignal.m */; };
-		D0AFE3681A0028A400C6048F /* RACEmptySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3521A0028A400C6048F /* RACEmptySequence.m */; };
-		D0AFE3691A0028A400C6048F /* RACEmptySignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3531A0028A400C6048F /* RACEmptySignal.m */; };
-		D0AFE36A1A0028A400C6048F /* RACErrorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3541A0028A400C6048F /* RACErrorSignal.m */; };
-		D0AFE36B1A0028A400C6048F /* RACEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3551A0028A400C6048F /* RACEvent.m */; };
-		D0AFE36C1A0028A400C6048F /* RACGroupedSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3561A0028A400C6048F /* RACGroupedSignal.m */; };
-		D0AFE36D1A0028A400C6048F /* RACImmediateScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3571A0028A400C6048F /* RACImmediateScheduler.m */; };
-		D0AFE36E1A0028A400C6048F /* RACMulticastConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3581A0028A400C6048F /* RACMulticastConnection.m */; };
-		D0AFE36F1A0028A400C6048F /* RACReplaySubject.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3591A0028A400C6048F /* RACReplaySubject.m */; };
-		D0AFE3701A0028A400C6048F /* RACReturnSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE35A1A0028A400C6048F /* RACReturnSignal.m */; };
-		D0AFE3711A0028A400C6048F /* RACScopedDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE35B1A0028A400C6048F /* RACScopedDisposable.m */; };
-		D0AFE3721A0028A400C6048F /* RACSerialDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE35C1A0028A400C6048F /* RACSerialDisposable.m */; };
-		D0AFE3731A0028A400C6048F /* RACSignalSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE35D1A0028A400C6048F /* RACSignalSequence.m */; };
-		D0AFE3741A0028A400C6048F /* RACStream.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE35E1A0028A400C6048F /* RACStream.m */; };
-		D0AFE3751A0028A400C6048F /* RACSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE35F1A0028A400C6048F /* RACSubject.m */; };
-		D0AFE3761A0028A400C6048F /* RACSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3601A0028A400C6048F /* RACSubscriber.m */; };
-		D0AFE3771A0028A400C6048F /* RACSubscriptionScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3611A0028A400C6048F /* RACSubscriptionScheduler.m */; };
-		D0AFE3781A0028A400C6048F /* RACTargetQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3621A0028A400C6048F /* RACTargetQueueScheduler.m */; };
-		D0AFE3791A0028A400C6048F /* RACTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3631A0028A400C6048F /* RACTuple.m */; };
-		D0AFE37A1A0028A400C6048F /* RACUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3641A0028A400C6048F /* RACUnit.m */; };
-		D0AFE37C1A0028B000C6048F /* RACCompoundDisposableProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE37B1A0028B000C6048F /* RACCompoundDisposableProvider.d */; };
-		D0AFE3811A0028CC00C6048F /* RACPassthroughSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE37D1A0028CC00C6048F /* RACPassthroughSubscriber.m */; };
-		D0AFE3821A0028CC00C6048F /* RACQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE37E1A0028CC00C6048F /* RACQueueScheduler.m */; };
-		D0AFE3831A0028CC00C6048F /* RACSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE37F1A0028CC00C6048F /* RACSequence.m */; };
-		D0AFE3841A0028CC00C6048F /* RACTupleSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3801A0028CC00C6048F /* RACTupleSequence.m */; };
-		D0AFE3861A0028D500C6048F /* RACSignalProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3851A0028D500C6048F /* RACSignalProvider.d */; };
-		D0AFE38B1A0028EC00C6048F /* RACArraySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3871A0028EC00C6048F /* RACArraySequence.m */; };
-		D0AFE38C1A0028EC00C6048F /* RACDynamicSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3881A0028EC00C6048F /* RACDynamicSequence.m */; };
-		D0AFE38D1A0028EC00C6048F /* RACEagerSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE3891A0028EC00C6048F /* RACEagerSequence.m */; };
-		D0AFE38E1A0028EC00C6048F /* RACUnarySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE38A1A0028EC00C6048F /* RACUnarySequence.m */; };
 		D0AFE3901A00294100C6048F /* SwiftSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0AFE38F1A00294100C6048F /* SwiftSpec.swift */; };
 		D0AFE3931A00297500C6048F /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0AFE3921A00297500C6048F /* Quick.framework */; };
 		D0AFE3951A0029A700C6048F /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0AFE3941A0029A700C6048F /* Nimble.framework */; };
@@ -148,14 +90,14 @@
 		D0EDBE9D17B0C68E0058BC3C /* NSError+SQRLVerbosityExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D0EDBE9B17B0C68E0058BC3C /* NSError+SQRLVerbosityExtensions.m */; };
 		D0EDBEDD17B0DB3E0058BC3C /* QuickSpec+SQRLFixtures.m in Sources */ = {isa = PBXBuildFile; fileRef = D0EDBEDC17B0DB3E0058BC3C /* QuickSpec+SQRLFixtures.m */; };
 		D0EDBEE117B0E3650058BC3C /* SQRLCodeSignatureSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D0EDBEE017B0E3650058BC3C /* SQRLCodeSignatureSpec.m */; };
-		D45F1A9218E46F2E005CE515 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909A18E46DFE00786EFE /* ReactiveCocoa.framework */; };
+		D45F1A9218E46F2E005CE515 /* ReactiveObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909A18E46DFE00786EFE /* ReactiveObjC.framework */; };
 		D45F1A9318E46F2E005CE515 /* Mantle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909818E46DE900786EFE /* Mantle.framework */; };
-		D45F1A9418E47055005CE515 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909A18E46DFE00786EFE /* ReactiveCocoa.framework */; };
+		D45F1A9418E47055005CE515 /* ReactiveObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909A18E46DFE00786EFE /* ReactiveObjC.framework */; };
 		D45F1A9518E47055005CE515 /* Mantle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909818E46DE900786EFE /* Mantle.framework */; };
 		D4ACA50118DB9F3F00EBD899 /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4ACA50018DB9F3F00EBD899 /* OHHTTPStubs.framework */; };
 		D4C4909918E46DE900786EFE /* Mantle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909818E46DE900786EFE /* Mantle.framework */; };
-		D4C4909B18E46DFE00786EFE /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909A18E46DFE00786EFE /* ReactiveCocoa.framework */; };
-		D4C4909E18E46E1000786EFE /* ReactiveCocoa.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909A18E46DFE00786EFE /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		D4C4909B18E46DFE00786EFE /* ReactiveObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909A18E46DFE00786EFE /* ReactiveObjC.framework */; };
+		D4C4909E18E46E1000786EFE /* ReactiveObjC.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909A18E46DFE00786EFE /* ReactiveObjC.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		D4C4909F18E46E1000786EFE /* Mantle.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D4C4909818E46DE900786EFE /* Mantle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F6EB2162179CFD93001108CF /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6EB2161179CFD93001108CF /* SystemConfiguration.framework */; };
 		F6EB2180179D0E4D001108CF /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6EB217F179D0E4D001108CF /* Security.framework */; };
@@ -241,7 +183,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				D08D4E4917B451F20012B22D /* Squirrel.framework in Copy Frameworks */,
-				D4C4909E18E46E1000786EFE /* ReactiveCocoa.framework in Copy Frameworks */,
+				D4C4909E18E46E1000786EFE /* ReactiveObjC.framework in Copy Frameworks */,
 				D4C4909F18E46E1000786EFE /* Mantle.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
@@ -287,9 +229,7 @@
 		88CA21911BD980FC006693B7 /* metamacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = metamacros.h; path = Carthage/Checkouts/Mantle/Mantle/extobjc/metamacros.h; sourceTree = SOURCE_ROOT; };
 		88CA21921BD980FC006693B7 /* MTLEXTKeyPathCoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MTLEXTKeyPathCoding.h; path = Carthage/Checkouts/Mantle/Mantle/extobjc/MTLEXTKeyPathCoding.h; sourceTree = SOURCE_ROOT; };
 		88CA21931BD980FC006693B7 /* MTLEXTRuntimeExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MTLEXTRuntimeExtensions.h; path = Carthage/Checkouts/Mantle/Mantle/extobjc/MTLEXTRuntimeExtensions.h; sourceTree = SOURCE_ROOT; };
-		88CA21941BD980FC006693B7 /* MTLEXTRuntimeExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MTLEXTRuntimeExtensions.m; path = Carthage/Checkouts/Mantle/Mantle/extobjc/MTLEXTRuntimeExtensions.m; sourceTree = SOURCE_ROOT; };
 		88CA21951BD980FC006693B7 /* MTLEXTScope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MTLEXTScope.h; path = Carthage/Checkouts/Mantle/Mantle/extobjc/MTLEXTScope.h; sourceTree = SOURCE_ROOT; };
-		88CA21961BD980FC006693B7 /* MTLEXTScope.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MTLEXTScope.m; path = Carthage/Checkouts/Mantle/Mantle/extobjc/MTLEXTScope.m; sourceTree = SOURCE_ROOT; };
 		D000218C17BACEFF0050109A /* SQRLZipArchiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQRLZipArchiver.h; sourceTree = "<group>"; };
 		D000218D17BACEFF0050109A /* SQRLZipArchiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLZipArchiver.m; sourceTree = "<group>"; };
 		D000219617BAD34D0050109A /* TestApplication.app.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = TestApplication.app.zip; sourceTree = "<group>"; };
@@ -317,7 +257,6 @@
 		D06B58B218032B1500656D97 /* RACSignal+SQRLTransactionExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RACSignal+SQRLTransactionExtensions.h"; sourceTree = "<group>"; };
 		D06B58B318032B1500656D97 /* RACSignal+SQRLTransactionExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RACSignal+SQRLTransactionExtensions.m"; sourceTree = "<group>"; };
 		D06B58D018035B5A00656D97 /* SQRLTerminationListenerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLTerminationListenerSpec.m; sourceTree = "<group>"; };
-		D06F7B0F1AD72DD30009A3BC /* RACKVOProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACKVOProxy.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACKVOProxy.m; sourceTree = SOURCE_ROOT; };
 		D08D4E0C17B451500012B22D /* TestApplication.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApplication.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D08D4E1017B451500012B22D /* TestApplication-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "TestApplication-Info.plist"; sourceTree = "<group>"; };
 		D08D4E1217B451500012B22D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -332,67 +271,10 @@
 		D0964B3A17F2E20B00D88BF7 /* NSBundle+SQRLVersionExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSBundle+SQRLVersionExtensions.h"; sourceTree = "<group>"; };
 		D0964B3B17F2E20B00D88BF7 /* NSBundle+SQRLVersionExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSBundle+SQRLVersionExtensions.m"; sourceTree = "<group>"; };
 		D097B9BC17BB4777006C3FEB /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
-		D09C66281A00520B007D7ED0 /* NSArray+RACSequenceAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSArray+RACSequenceAdditions.m"; path = "Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/NSArray+RACSequenceAdditions.m"; sourceTree = SOURCE_ROOT; };
-		D09C662A1A005226007D7ED0 /* NSObject+RACKVOWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACKVOWrapper.m"; path = "Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/NSObject+RACKVOWrapper.m"; sourceTree = SOURCE_ROOT; };
-		D09C662B1A005226007D7ED0 /* NSObject+RACPropertySubscribing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACPropertySubscribing.m"; path = "Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/NSObject+RACPropertySubscribing.m"; sourceTree = SOURCE_ROOT; };
-		D09C66341A00535B007D7ED0 /* RACKVOTrampoline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACKVOTrampoline.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACKVOTrampoline.m; sourceTree = SOURCE_ROOT; };
-		D09C66361A00537A007D7ED0 /* NSObject+RACDeallocating.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACDeallocating.m"; path = "Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/NSObject+RACDeallocating.m"; sourceTree = SOURCE_ROOT; };
-		D09C66371A00537A007D7ED0 /* NSObject+RACDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACDescription.m"; path = "Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/NSObject+RACDescription.m"; sourceTree = SOURCE_ROOT; };
-		D09C663A1A00538D007D7ED0 /* RACObjCRuntime.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACObjCRuntime.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACObjCRuntime.m; sourceTree = SOURCE_ROOT; };
-		D09C663C1A0053C6007D7ED0 /* NSString+RACKeyPathUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACKeyPathUtilities.m"; path = "Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/NSString+RACKeyPathUtilities.m"; sourceTree = SOURCE_ROOT; };
-		D09C663E1A005433007D7ED0 /* NSEnumerator+RACSequenceAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSEnumerator+RACSequenceAdditions.m"; path = "Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/NSEnumerator+RACSequenceAdditions.m"; sourceTree = SOURCE_ROOT; };
-		D09C66401A005592007D7ED0 /* MTLModel+NSCoding.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "MTLModel+NSCoding.m"; path = "Carthage/Checkouts/Mantle/Mantle/MTLModel+NSCoding.m"; sourceTree = SOURCE_ROOT; };
-		D09C66421A0055E6007D7ED0 /* NSArray+MTLManipulationAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSArray+MTLManipulationAdditions.m"; path = "Carthage/Checkouts/Mantle/Mantle/NSArray+MTLManipulationAdditions.m"; sourceTree = SOURCE_ROOT; };
-		D09C66431A0055E6007D7ED0 /* NSDictionary+MTLManipulationAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+MTLManipulationAdditions.m"; path = "Carthage/Checkouts/Mantle/Mantle/NSDictionary+MTLManipulationAdditions.m"; sourceTree = SOURCE_ROOT; };
-		D09C66441A0055E6007D7ED0 /* NSError+MTLModelException.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+MTLModelException.m"; path = "Carthage/Checkouts/Mantle/Mantle/NSError+MTLModelException.m"; sourceTree = SOURCE_ROOT; };
-		D09C66451A0055E6007D7ED0 /* NSObject+MTLComparisonAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+MTLComparisonAdditions.m"; path = "Carthage/Checkouts/Mantle/Mantle/NSObject+MTLComparisonAdditions.m"; sourceTree = SOURCE_ROOT; };
-		D09C664A1A0055F3007D7ED0 /* NSValueTransformer+MTLInversionAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+MTLInversionAdditions.m"; path = "Carthage/Checkouts/Mantle/Mantle/NSValueTransformer+MTLInversionAdditions.m"; sourceTree = SOURCE_ROOT; };
 		D09D244017B595470001FAF8 /* SQRLInstallerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLInstallerSpec.m; sourceTree = "<group>"; };
 		D09D244917B59AB30001FAF8 /* TestApplication 2.1.app */ = {isa = PBXFileReference; lastKnownFileType = wrapper.application; path = "TestApplication 2.1.app"; sourceTree = "<group>"; };
 		D0AFE3351A00236E00C6048F /* Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Framework.xcconfig; sourceTree = "<group>"; };
 		D0AFE3361A00237400C6048F /* iOS-Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "iOS-Framework.xcconfig"; sourceTree = "<group>"; };
-		D0AFE3381A00282C00C6048F /* MTLJSONAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MTLJSONAdapter.m; path = Carthage/Checkouts/Mantle/Mantle/MTLJSONAdapter.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3391A00282C00C6048F /* MTLModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MTLModel.m; path = Carthage/Checkouts/Mantle/Mantle/MTLModel.m; sourceTree = SOURCE_ROOT; };
-		D0AFE33A1A00282C00C6048F /* MTLValueTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MTLValueTransformer.m; path = Carthage/Checkouts/Mantle/Mantle/MTLValueTransformer.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3411A00285000C6048F /* MTLReflection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MTLReflection.m; path = Carthage/Checkouts/Mantle/Mantle/MTLReflection.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3421A00285000C6048F /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+MTLPredefinedTransformerAdditions.m"; path = "Carthage/Checkouts/Mantle/Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m"; sourceTree = SOURCE_ROOT; };
-		D0AFE3451A00287100C6048F /* RACCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACCommand.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACCommand.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3461A00287100C6048F /* RACDisposable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACDisposable.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACDisposable.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3471A00287100C6048F /* RACScheduler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACScheduler.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACScheduler.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3481A00287100C6048F /* RACSignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACSignal.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACSignal.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3491A00287100C6048F /* RACSignal+Operations.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RACSignal+Operations.m"; path = "Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACSignal+Operations.m"; sourceTree = SOURCE_ROOT; };
-		D0AFE34F1A0028A400C6048F /* RACBlockTrampoline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACBlockTrampoline.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACBlockTrampoline.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3501A0028A400C6048F /* RACCompoundDisposable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACCompoundDisposable.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACCompoundDisposable.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3511A0028A400C6048F /* RACDynamicSignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSignal.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACDynamicSignal.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3521A0028A400C6048F /* RACEmptySequence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACEmptySequence.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACEmptySequence.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3531A0028A400C6048F /* RACEmptySignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACEmptySignal.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACEmptySignal.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3541A0028A400C6048F /* RACErrorSignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACErrorSignal.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACErrorSignal.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3551A0028A400C6048F /* RACEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACEvent.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACEvent.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3561A0028A400C6048F /* RACGroupedSignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACGroupedSignal.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACGroupedSignal.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3571A0028A400C6048F /* RACImmediateScheduler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACImmediateScheduler.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACImmediateScheduler.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3581A0028A400C6048F /* RACMulticastConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACMulticastConnection.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACMulticastConnection.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3591A0028A400C6048F /* RACReplaySubject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACReplaySubject.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACReplaySubject.m; sourceTree = SOURCE_ROOT; };
-		D0AFE35A1A0028A400C6048F /* RACReturnSignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACReturnSignal.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACReturnSignal.m; sourceTree = SOURCE_ROOT; };
-		D0AFE35B1A0028A400C6048F /* RACScopedDisposable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACScopedDisposable.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACScopedDisposable.m; sourceTree = SOURCE_ROOT; };
-		D0AFE35C1A0028A400C6048F /* RACSerialDisposable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACSerialDisposable.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACSerialDisposable.m; sourceTree = SOURCE_ROOT; };
-		D0AFE35D1A0028A400C6048F /* RACSignalSequence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACSignalSequence.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACSignalSequence.m; sourceTree = SOURCE_ROOT; };
-		D0AFE35E1A0028A400C6048F /* RACStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACStream.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACStream.m; sourceTree = SOURCE_ROOT; };
-		D0AFE35F1A0028A400C6048F /* RACSubject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACSubject.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACSubject.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3601A0028A400C6048F /* RACSubscriber.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACSubscriber.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACSubscriber.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3611A0028A400C6048F /* RACSubscriptionScheduler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACSubscriptionScheduler.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACSubscriptionScheduler.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3621A0028A400C6048F /* RACTargetQueueScheduler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACTargetQueueScheduler.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACTargetQueueScheduler.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3631A0028A400C6048F /* RACTuple.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACTuple.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACTuple.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3641A0028A400C6048F /* RACUnit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACUnit.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACUnit.m; sourceTree = SOURCE_ROOT; };
-		D0AFE37B1A0028B000C6048F /* RACCompoundDisposableProvider.d */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.dtrace; name = RACCompoundDisposableProvider.d; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACCompoundDisposableProvider.d; sourceTree = SOURCE_ROOT; };
-		D0AFE37D1A0028CC00C6048F /* RACPassthroughSubscriber.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACPassthroughSubscriber.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACPassthroughSubscriber.m; sourceTree = SOURCE_ROOT; };
-		D0AFE37E1A0028CC00C6048F /* RACQueueScheduler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACQueueScheduler.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACQueueScheduler.m; sourceTree = SOURCE_ROOT; };
-		D0AFE37F1A0028CC00C6048F /* RACSequence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACSequence.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACSequence.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3801A0028CC00C6048F /* RACTupleSequence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACTupleSequence.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACTupleSequence.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3851A0028D500C6048F /* RACSignalProvider.d */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.dtrace; name = RACSignalProvider.d; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACSignalProvider.d; sourceTree = SOURCE_ROOT; };
-		D0AFE3871A0028EC00C6048F /* RACArraySequence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACArraySequence.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACArraySequence.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3881A0028EC00C6048F /* RACDynamicSequence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSequence.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACDynamicSequence.m; sourceTree = SOURCE_ROOT; };
-		D0AFE3891A0028EC00C6048F /* RACEagerSequence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACEagerSequence.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACEagerSequence.m; sourceTree = SOURCE_ROOT; };
-		D0AFE38A1A0028EC00C6048F /* RACUnarySequence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RACUnarySequence.m; path = Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/RACUnarySequence.m; sourceTree = SOURCE_ROOT; };
 		D0AFE38F1A00294100C6048F /* SwiftSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSpec.swift; sourceTree = "<group>"; };
 		D0AFE3921A00297500C6048F /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0AFE3941A0029A700C6048F /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -431,7 +313,7 @@
 		D0EDBEE017B0E3650058BC3C /* SQRLCodeSignatureSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLCodeSignatureSpec.m; sourceTree = "<group>"; };
 		D4ACA50018DB9F3F00EBD899 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = External/OHHTTPStubs/OHHTTPStubs/build/Debug/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		D4C4909818E46DE900786EFE /* Mantle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mantle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D4C4909A18E46DFE00786EFE /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ReactiveCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D4C4909A18E46DFE00786EFE /* ReactiveObjC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ReactiveObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F60CA7EA179FC4F60069F69A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		F65A915F17A71AA5005A4666 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		F6EB2161179CFD93001108CF /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -457,6 +339,8 @@
 				D014AC1F17B979C4007D79D0 /* Cocoa.framework in Frameworks */,
 				D014AC1D17B979B7007D79D0 /* Security.framework in Frameworks */,
 				D014AC1E17B979BD007D79D0 /* ServiceManagement.framework in Frameworks */,
+				E0A1D0102DB8C00100000010 /* Mantle.framework in Frameworks */,
+				E0A1D0112DB8C00100000011 /* ReactiveObjC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -466,7 +350,7 @@
 			files = (
 				D08D4E4717B451E50012B22D /* Squirrel.framework in Frameworks */,
 				D08D4E0D17B451500012B22D /* Cocoa.framework in Frameworks */,
-				D45F1A9418E47055005CE515 /* ReactiveCocoa.framework in Frameworks */,
+				D45F1A9418E47055005CE515 /* ReactiveObjC.framework in Frameworks */,
 				D45F1A9518E47055005CE515 /* Mantle.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -481,7 +365,7 @@
 				533076EB17EB688300BDCCE0 /* IOKit.framework in Frameworks */,
 				D0C22BDB179CC00E00158214 /* Cocoa.framework in Frameworks */,
 				D4C4909918E46DE900786EFE /* Mantle.framework in Frameworks */,
-				D4C4909B18E46DFE00786EFE /* ReactiveCocoa.framework in Frameworks */,
+				D4C4909B18E46DFE00786EFE /* ReactiveObjC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -497,7 +381,7 @@
 				D0AFE3951A0029A700C6048F /* Nimble.framework in Frameworks */,
 				D0A6D2BC17B9FA9E00B2C3DF /* Security.framework in Frameworks */,
 				D0C22BF5179CC00E00158214 /* Squirrel.framework in Frameworks */,
-				D45F1A9218E46F2E005CE515 /* ReactiveCocoa.framework in Frameworks */,
+				D45F1A9218E46F2E005CE515 /* ReactiveObjC.framework in Frameworks */,
 				D45F1A9318E46F2E005CE515 /* Mantle.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -689,67 +573,7 @@
 				88CA21911BD980FC006693B7 /* metamacros.h */,
 				88CA21921BD980FC006693B7 /* MTLEXTKeyPathCoding.h */,
 				88CA21931BD980FC006693B7 /* MTLEXTRuntimeExtensions.h */,
-				88CA21941BD980FC006693B7 /* MTLEXTRuntimeExtensions.m */,
 				88CA21951BD980FC006693B7 /* MTLEXTScope.h */,
-				88CA21961BD980FC006693B7 /* MTLEXTScope.m */,
-				D0AFE3381A00282C00C6048F /* MTLJSONAdapter.m */,
-				D0AFE3391A00282C00C6048F /* MTLModel.m */,
-				D09C66401A005592007D7ED0 /* MTLModel+NSCoding.m */,
-				D0AFE3411A00285000C6048F /* MTLReflection.m */,
-				D0AFE33A1A00282C00C6048F /* MTLValueTransformer.m */,
-				D09C66421A0055E6007D7ED0 /* NSArray+MTLManipulationAdditions.m */,
-				D09C66281A00520B007D7ED0 /* NSArray+RACSequenceAdditions.m */,
-				D09C66431A0055E6007D7ED0 /* NSDictionary+MTLManipulationAdditions.m */,
-				D09C663E1A005433007D7ED0 /* NSEnumerator+RACSequenceAdditions.m */,
-				D09C66441A0055E6007D7ED0 /* NSError+MTLModelException.m */,
-				D09C664A1A0055F3007D7ED0 /* NSValueTransformer+MTLInversionAdditions.m */,
-				D09C66451A0055E6007D7ED0 /* NSObject+MTLComparisonAdditions.m */,
-				D09C66361A00537A007D7ED0 /* NSObject+RACDeallocating.m */,
-				D09C66371A00537A007D7ED0 /* NSObject+RACDescription.m */,
-				D09C662A1A005226007D7ED0 /* NSObject+RACKVOWrapper.m */,
-				D09C662B1A005226007D7ED0 /* NSObject+RACPropertySubscribing.m */,
-				D09C663C1A0053C6007D7ED0 /* NSString+RACKeyPathUtilities.m */,
-				D0AFE3421A00285000C6048F /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */,
-				D0AFE3871A0028EC00C6048F /* RACArraySequence.m */,
-				D0AFE34F1A0028A400C6048F /* RACBlockTrampoline.m */,
-				D0AFE3451A00287100C6048F /* RACCommand.m */,
-				D0AFE3501A0028A400C6048F /* RACCompoundDisposable.m */,
-				D0AFE37B1A0028B000C6048F /* RACCompoundDisposableProvider.d */,
-				D0AFE3461A00287100C6048F /* RACDisposable.m */,
-				D0AFE3881A0028EC00C6048F /* RACDynamicSequence.m */,
-				D0AFE3511A0028A400C6048F /* RACDynamicSignal.m */,
-				D0AFE3891A0028EC00C6048F /* RACEagerSequence.m */,
-				D0AFE3521A0028A400C6048F /* RACEmptySequence.m */,
-				D0AFE3531A0028A400C6048F /* RACEmptySignal.m */,
-				D0AFE3541A0028A400C6048F /* RACErrorSignal.m */,
-				D0AFE3551A0028A400C6048F /* RACEvent.m */,
-				D0AFE3561A0028A400C6048F /* RACGroupedSignal.m */,
-				D0AFE3571A0028A400C6048F /* RACImmediateScheduler.m */,
-				D06F7B0F1AD72DD30009A3BC /* RACKVOProxy.m */,
-				D09C66341A00535B007D7ED0 /* RACKVOTrampoline.m */,
-				D0AFE3581A0028A400C6048F /* RACMulticastConnection.m */,
-				D09C663A1A00538D007D7ED0 /* RACObjCRuntime.m */,
-				D0AFE37D1A0028CC00C6048F /* RACPassthroughSubscriber.m */,
-				D0AFE37E1A0028CC00C6048F /* RACQueueScheduler.m */,
-				D0AFE3591A0028A400C6048F /* RACReplaySubject.m */,
-				D0AFE35A1A0028A400C6048F /* RACReturnSignal.m */,
-				D0AFE3471A00287100C6048F /* RACScheduler.m */,
-				D0AFE35B1A0028A400C6048F /* RACScopedDisposable.m */,
-				D0AFE37F1A0028CC00C6048F /* RACSequence.m */,
-				D0AFE35C1A0028A400C6048F /* RACSerialDisposable.m */,
-				D0AFE3481A00287100C6048F /* RACSignal.m */,
-				D0AFE3491A00287100C6048F /* RACSignal+Operations.m */,
-				D0AFE3851A0028D500C6048F /* RACSignalProvider.d */,
-				D0AFE35D1A0028A400C6048F /* RACSignalSequence.m */,
-				D0AFE35E1A0028A400C6048F /* RACStream.m */,
-				D0AFE35F1A0028A400C6048F /* RACSubject.m */,
-				D0AFE3601A0028A400C6048F /* RACSubscriber.m */,
-				D0AFE3611A0028A400C6048F /* RACSubscriptionScheduler.m */,
-				D0AFE3621A0028A400C6048F /* RACTargetQueueScheduler.m */,
-				D0AFE3631A0028A400C6048F /* RACTuple.m */,
-				D0AFE3801A0028CC00C6048F /* RACTupleSequence.m */,
-				D0AFE38A1A0028EC00C6048F /* RACUnarySequence.m */,
-				D0AFE3641A0028A400C6048F /* RACUnit.m */,
 			);
 			name = "Static Dependencies";
 			sourceTree = "<group>";
@@ -787,7 +611,7 @@
 			children = (
 				D0AFE3941A0029A700C6048F /* Nimble.framework */,
 				D0AFE3921A00297500C6048F /* Quick.framework */,
-				D4C4909A18E46DFE00786EFE /* ReactiveCocoa.framework */,
+				D4C4909A18E46DFE00786EFE /* ReactiveObjC.framework */,
 				D4C4909818E46DE900786EFE /* Mantle.framework */,
 				D4ACA50018DB9F3F00EBD899 /* OHHTTPStubs.framework */,
 				D097B9BC17BB4777006C3FEB /* IOKit.framework */,
@@ -1179,76 +1003,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D0AFE36F1A0028A400C6048F /* RACReplaySubject.m in Sources */,
-				D0AFE3681A0028A400C6048F /* RACEmptySequence.m in Sources */,
-				D09C663F1A005433007D7ED0 /* NSEnumerator+RACSequenceAdditions.m in Sources */,
-				D09C66471A0055E6007D7ED0 /* NSDictionary+MTLManipulationAdditions.m in Sources */,
-				D0AFE34C1A00287100C6048F /* RACScheduler.m in Sources */,
 				D014AC1117B9789C007D79D0 /* SQRLInstaller.m in Sources */,
 				D043F77217FF40C90012F996 /* SQRLTerminationListener.m in Sources */,
-				D09C66481A0055E6007D7ED0 /* NSError+MTLModelException.m in Sources */,
-				D0AFE3781A0028A400C6048F /* RACTargetQueueScheduler.m in Sources */,
-				D0AFE3651A0028A400C6048F /* RACBlockTrampoline.m in Sources */,
-				D0AFE3711A0028A400C6048F /* RACScopedDisposable.m in Sources */,
-				D0AFE3661A0028A400C6048F /* RACCompoundDisposable.m in Sources */,
-				D0AFE37C1A0028B000C6048F /* RACCompoundDisposableProvider.d in Sources */,
-				D0AFE3441A00285000C6048F /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
-				D0AFE38B1A0028EC00C6048F /* RACArraySequence.m in Sources */,
-				D06F7B101AD72DD30009A3BC /* RACKVOProxy.m in Sources */,
-				D0AFE3751A0028A400C6048F /* RACSubject.m in Sources */,
 				D014AC0517B97885007D79D0 /* ShipIt-main.m in Sources */,
-				D0AFE3431A00285000C6048F /* MTLReflection.m in Sources */,
-				D0AFE3741A0028A400C6048F /* RACStream.m in Sources */,
-				D0AFE38D1A0028EC00C6048F /* RACEagerSequence.m in Sources */,
-				D0AFE37A1A0028A400C6048F /* RACUnit.m in Sources */,
-				D0AFE34D1A00287100C6048F /* RACSignal.m in Sources */,
-				D09C663B1A00538D007D7ED0 /* RACObjCRuntime.m in Sources */,
 				D014AC1917B979A8007D79D0 /* SQRLCodeSignature.m in Sources */,
-				D0AFE34A1A00287100C6048F /* RACCommand.m in Sources */,
-				D09C66381A00537A007D7ED0 /* NSObject+RACDeallocating.m in Sources */,
 				5397A5D0187D92810014A477 /* SQRLShipItRequest.m in Sources */,
-				D09C66461A0055E6007D7ED0 /* NSArray+MTLManipulationAdditions.m in Sources */,
 				D06B58B618032B1500656D97 /* RACSignal+SQRLTransactionExtensions.m in Sources */,
-				D0AFE33D1A00282C00C6048F /* MTLValueTransformer.m in Sources */,
-				D0AFE3841A0028CC00C6048F /* RACTupleSequence.m in Sources */,
 				5397A5EC187DA2570014A477 /* SQRLInstallerOwnedBundle.m in Sources */,
 				D014AC1A17B979AA007D79D0 /* NSError+SQRLVerbosityExtensions.m in Sources */,
-				D09C66411A005592007D7ED0 /* MTLModel+NSCoding.m in Sources */,
-				D09C664B1A0055F3007D7ED0 /* NSValueTransformer+MTLInversionAdditions.m in Sources */,
-				D0AFE36E1A0028A400C6048F /* RACMulticastConnection.m in Sources */,
-				D0AFE34E1A00287100C6048F /* RACSignal+Operations.m in Sources */,
-				D09C66491A0055E6007D7ED0 /* NSObject+MTLComparisonAdditions.m in Sources */,
-				D0AFE38C1A0028EC00C6048F /* RACDynamicSequence.m in Sources */,
-				D09C662C1A005226007D7ED0 /* NSObject+RACKVOWrapper.m in Sources */,
-				D0AFE3821A0028CC00C6048F /* RACQueueScheduler.m in Sources */,
-				D0AFE3771A0028A400C6048F /* RACSubscriptionScheduler.m in Sources */,
-				D0AFE38E1A0028EC00C6048F /* RACUnarySequence.m in Sources */,
-				D0AFE33B1A00282C00C6048F /* MTLJSONAdapter.m in Sources */,
-				D09C66351A00535B007D7ED0 /* RACKVOTrampoline.m in Sources */,
-				88CA21981BD980FC006693B7 /* MTLEXTScope.m in Sources */,
-				D0AFE3691A0028A400C6048F /* RACEmptySignal.m in Sources */,
-				D09C66391A00537A007D7ED0 /* NSObject+RACDescription.m in Sources */,
 				D0D2B6271804E903000EA901 /* SQRLDirectoryManager.m in Sources */,
-				D0AFE36D1A0028A400C6048F /* RACImmediateScheduler.m in Sources */,
-				D0AFE36A1A0028A400C6048F /* RACErrorSignal.m in Sources */,
-				D0AFE3791A0028A400C6048F /* RACTuple.m in Sources */,
-				D0AFE3811A0028CC00C6048F /* RACPassthroughSubscriber.m in Sources */,
-				D0AFE3721A0028A400C6048F /* RACSerialDisposable.m in Sources */,
 				D0964B3E17F2E20B00D88BF7 /* NSBundle+SQRLVersionExtensions.m in Sources */,
-				D0AFE36C1A0028A400C6048F /* RACGroupedSignal.m in Sources */,
-				D0AFE34B1A00287100C6048F /* RACDisposable.m in Sources */,
-				D0AFE3731A0028A400C6048F /* RACSignalSequence.m in Sources */,
-				88CA21971BD980FC006693B7 /* MTLEXTRuntimeExtensions.m in Sources */,
-				D09C662D1A005226007D7ED0 /* NSObject+RACPropertySubscribing.m in Sources */,
-				D0AFE3861A0028D500C6048F /* RACSignalProvider.d in Sources */,
-				D0AFE36B1A0028A400C6048F /* RACEvent.m in Sources */,
-				D0AFE3831A0028CC00C6048F /* RACSequence.m in Sources */,
-				D0AFE3671A0028A400C6048F /* RACDynamicSignal.m in Sources */,
-				D0AFE3761A0028A400C6048F /* RACSubscriber.m in Sources */,
-				D0AFE33C1A00282C00C6048F /* MTLModel.m in Sources */,
-				D09C66291A00520B007D7ED0 /* NSArray+RACSequenceAdditions.m in Sources */,
-				D09C663D1A0053C6007D7ED0 /* NSString+RACKeyPathUtilities.m in Sources */,
-				D0AFE3701A0028A400C6048F /* RACReturnSignal.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1420,15 +1184,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0C22C17179CC02E00158214 /* Mac-Application.xcconfig */;
 			buildSettings = {
-				GCC_PREPROCESSOR_DEFINITIONS = (
+				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
-					"mtl_copyPropertyAttributes=rac_copyPropertyAttributes",
-					"mtl_propertyAttributes=rac_propertyAttributes",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					Carthage/Checkouts/Mantle,
-					"Carthage/Checkouts/ReactiveCocoa/**",
+					"@executable_path/../../../..",
+					"@executable_path/../..",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1439,15 +1198,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0C22C17179CC02E00158214 /* Mac-Application.xcconfig */;
 			buildSettings = {
-				GCC_PREPROCESSOR_DEFINITIONS = (
+				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
-					"mtl_copyPropertyAttributes=rac_copyPropertyAttributes",
-					"mtl_propertyAttributes=rac_propertyAttributes",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					Carthage/Checkouts/Mantle,
-					"Carthage/Checkouts/ReactiveCocoa/**",
+					"@executable_path/../../../..",
+					"@executable_path/../..",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1458,15 +1212,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0C22C17179CC02E00158214 /* Mac-Application.xcconfig */;
 			buildSettings = {
-				GCC_PREPROCESSOR_DEFINITIONS = (
+				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
-					"mtl_copyPropertyAttributes=rac_copyPropertyAttributes",
-					"mtl_propertyAttributes=rac_propertyAttributes",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					Carthage/Checkouts/Mantle,
-					"Carthage/Checkouts/ReactiveCocoa/**",
+					"@executable_path/../../../..",
+					"@executable_path/../..",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1477,15 +1226,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0C22C17179CC02E00158214 /* Mac-Application.xcconfig */;
 			buildSettings = {
-				GCC_PREPROCESSOR_DEFINITIONS = (
+				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
-					"mtl_copyPropertyAttributes=rac_copyPropertyAttributes",
-					"mtl_propertyAttributes=rac_propertyAttributes",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					Carthage/Checkouts/Mantle,
-					"Carthage/Checkouts/ReactiveCocoa/**",
+					"@executable_path/../../../..",
+					"@executable_path/../..",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1606,7 +1350,7 @@
 				FRAMEWORK_VERSION = A;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/extobjc,
+					Carthage/Checkouts/ReactiveObjC/ReactiveObjC/extobjc,
 				);
 				INFOPLIST_FILE = "Squirrel/Squirrel-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.${PRODUCT_NAME:rfc1034identifier}";
@@ -1625,7 +1369,7 @@
 				FRAMEWORK_VERSION = A;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/extobjc,
+					Carthage/Checkouts/ReactiveObjC/ReactiveObjC/extobjc,
 				);
 				INFOPLIST_FILE = "Squirrel/Squirrel-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.${PRODUCT_NAME:rfc1034identifier}";
@@ -1643,7 +1387,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/extobjc,
+					Carthage/Checkouts/ReactiveObjC/ReactiveObjC/extobjc,
 				);
 				INFOPLIST_FILE = "SquirrelTests/SquirrelTests-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
@@ -1663,7 +1407,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/extobjc,
+					Carthage/Checkouts/ReactiveObjC/ReactiveObjC/extobjc,
 				);
 				INFOPLIST_FILE = "SquirrelTests/SquirrelTests-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
@@ -1699,7 +1443,7 @@
 				FRAMEWORK_VERSION = A;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/extobjc,
+					Carthage/Checkouts/ReactiveObjC/ReactiveObjC/extobjc,
 				);
 				INFOPLIST_FILE = "Squirrel/Squirrel-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.${PRODUCT_NAME:rfc1034identifier}";
@@ -1717,7 +1461,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/extobjc,
+					Carthage/Checkouts/ReactiveObjC/ReactiveObjC/extobjc,
 				);
 				INFOPLIST_FILE = "SquirrelTests/SquirrelTests-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
@@ -1752,7 +1496,7 @@
 				FRAMEWORK_VERSION = A;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/extobjc,
+					Carthage/Checkouts/ReactiveObjC/ReactiveObjC/extobjc,
 				);
 				INFOPLIST_FILE = "Squirrel/Squirrel-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.${PRODUCT_NAME:rfc1034identifier}";
@@ -1770,7 +1514,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/extobjc,
+					Carthage/Checkouts/ReactiveObjC/ReactiveObjC/extobjc,
 				);
 				INFOPLIST_FILE = "SquirrelTests/SquirrelTests-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;

--- a/Squirrel.xcworkspace/contents.xcworkspacedata
+++ b/Squirrel.xcworkspace/contents.xcworkspacedata
@@ -8,7 +8,7 @@
       location = "group:Carthage/Checkouts/Mantle/Mantle.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa.xcodeproj">
+      location = "group:Carthage/Checkouts/ReactiveObjC/ReactiveObjC.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:External/OHHTTPStubs/OHHTTPStubs/OHHTTPStubs.xcodeproj">

--- a/Squirrel/RACSignal+SQRLTransactionExtensions.h
+++ b/Squirrel/RACSignal+SQRLTransactionExtensions.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 GitHub. All rights reserved.
 //
 
-#import <ReactiveCocoa/RACSignal.h>
+#import <ReactiveObjC/RACSignal.h>
 
 @interface RACSignal (SQRLTransactionExtensions)
 

--- a/Squirrel/RACSignal+SQRLTransactionExtensions.m
+++ b/Squirrel/RACSignal+SQRLTransactionExtensions.m
@@ -8,7 +8,7 @@
 
 #import "RACSignal+SQRLTransactionExtensions.h"
 
-#import <ReactiveCocoa/RACDisposable.h>
+#import <ReactiveObjC/RACDisposable.h>
 #import <IOKit/pwr_mgt/IOPMLib.h>
 
 // How long before power assertions time out.

--- a/Squirrel/SQRLCodeSignature.m
+++ b/Squirrel/SQRLCodeSignature.m
@@ -8,10 +8,10 @@
 
 #import "SQRLCodeSignature.h"
 
-#import "EXTKeyPathCoding.h"
-#import "EXTScope.h"
-#import <ReactiveCocoa/RACSignal+Operations.h>
-#import <ReactiveCocoa/RACSubscriber.h>
+#import <ReactiveObjC/EXTKeyPathCoding.h>
+#import <ReactiveObjC/EXTScope.h>
+#import <ReactiveObjC/RACSignal+Operations.h>
+#import <ReactiveObjC/RACSubscriber.h>
 #import <Security/Security.h>
 
 NSString * const SQRLCodeSignatureErrorDomain = @"SQRLCodeSignatureErrorDomain";

--- a/Squirrel/SQRLDirectoryManager.m
+++ b/Squirrel/SQRLDirectoryManager.m
@@ -8,7 +8,7 @@
 
 #import "SQRLDirectoryManager.h"
 
-#import <ReactiveCocoa/RACSignal+Operations.h>
+#import <ReactiveObjC/RACSignal+Operations.h>
 
 @implementation SQRLDirectoryManager
 

--- a/Squirrel/SQRLDownloadedUpdate.m
+++ b/Squirrel/SQRLDownloadedUpdate.m
@@ -7,7 +7,7 @@
 //
 
 #import "SQRLDownloadedUpdate.h"
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 
 @interface SQRLDownloadedUpdate ()
 

--- a/Squirrel/SQRLInstaller.m
+++ b/Squirrel/SQRLInstaller.m
@@ -9,13 +9,13 @@
 #import "SQRLInstaller.h"
 
 #import <libkern/OSAtomic.h>
-#import "EXTScope.h"
-#import <ReactiveCocoa/NSEnumerator+RACSequenceAdditions.h>
-#import <ReactiveCocoa/NSObject+RACPropertySubscribing.h>
-#import <ReactiveCocoa/RACCommand.h>
-#import <ReactiveCocoa/RACSequence.h>
-#import <ReactiveCocoa/RACSignal+Operations.h>
-#import <ReactiveCocoa/RACSubscriber.h>
+#import <ReactiveObjC/EXTScope.h>
+#import <ReactiveObjC/NSEnumerator+RACSequenceAdditions.h>
+#import <ReactiveObjC/NSObject+RACPropertySubscribing.h>
+#import <ReactiveObjC/RACCommand.h>
+#import <ReactiveObjC/RACSequence.h>
+#import <ReactiveObjC/RACSignal+Operations.h>
+#import <ReactiveObjC/RACSubscriber.h>
 #import <sys/xattr.h>
 
 #import "NSBundle+SQRLVersionExtensions.h"

--- a/Squirrel/SQRLInstallerOwnedBundle.m
+++ b/Squirrel/SQRLInstallerOwnedBundle.m
@@ -8,7 +8,7 @@
 
 #import "SQRLInstallerOwnedBundle.h"
 
-#import "EXTKeyPathCoding.h"
+#import <ReactiveObjC/EXTKeyPathCoding.h>
 
 @implementation SQRLInstallerOwnedBundle
 

--- a/Squirrel/SQRLShipItLauncher.m
+++ b/Squirrel/SQRLShipItLauncher.m
@@ -7,9 +7,9 @@
 //
 
 #import "SQRLShipItLauncher.h"
-#import "EXTScope.h"
+#import <ReactiveObjC/EXTScope.h>
 #import "SQRLDirectoryManager.h"
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 #import <Security/Security.h>
 #import <ServiceManagement/ServiceManagement.h>
 #import <launch.h>

--- a/Squirrel/SQRLShipItRequest.m
+++ b/Squirrel/SQRLShipItRequest.m
@@ -8,8 +8,8 @@
 
 #import "SQRLShipItRequest.h"
 
-#import "EXTKeyPathCoding.h"
-#import <ReactiveCocoa/RACSignal+Operations.h>
+#import <ReactiveObjC/EXTKeyPathCoding.h>
+#import <ReactiveObjC/RACSignal+Operations.h>
 
 NSString * const SQRLShipItRequestErrorDomain = @"SQRLShipItRequestErrorDomain";
 
@@ -60,7 +60,13 @@ NSString * const SQRLShipItRequestPropertyErrorKey = @"SQRLShipItRequestProperty
 #pragma mark Serialization
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{};
+	return @{
+		@keypath(SQRLShipItRequest.new, updateBundleURL): @keypath(SQRLShipItRequest.new, updateBundleURL),
+		@keypath(SQRLShipItRequest.new, targetBundleURL): @keypath(SQRLShipItRequest.new, targetBundleURL),
+		@keypath(SQRLShipItRequest.new, bundleIdentifier): @keypath(SQRLShipItRequest.new, bundleIdentifier),
+		@keypath(SQRLShipItRequest.new, launchAfterInstallation): @keypath(SQRLShipItRequest.new, launchAfterInstallation),
+		@keypath(SQRLShipItRequest.new, useUpdateBundleName): @keypath(SQRLShipItRequest.new, useUpdateBundleName),
+	};
 }
 
 + (NSValueTransformer *)updateBundleURLJSONTransformer {

--- a/Squirrel/SQRLTerminationListener.m
+++ b/Squirrel/SQRLTerminationListener.m
@@ -8,13 +8,13 @@
 
 #import "SQRLTerminationListener.h"
 
-#import "EXTKeyPathCoding.h"
-#import <ReactiveCocoa/NSArray+RACSequenceAdditions.h>
-#import <ReactiveCocoa/RACDisposable.h>
-#import <ReactiveCocoa/RACScheduler.h>
-#import <ReactiveCocoa/RACSequence.h>
-#import <ReactiveCocoa/RACSignal+Operations.h>
-#import <ReactiveCocoa/RACSubscriber.h>
+#import <ReactiveObjC/EXTKeyPathCoding.h>
+#import <ReactiveObjC/NSArray+RACSequenceAdditions.h>
+#import <ReactiveObjC/RACDisposable.h>
+#import <ReactiveObjC/RACScheduler.h>
+#import <ReactiveObjC/RACSequence.h>
+#import <ReactiveObjC/RACSignal+Operations.h>
+#import <ReactiveObjC/RACSubscriber.h>
 
 @interface SQRLTerminationListener ()
 

--- a/Squirrel/SQRLUpdate.m
+++ b/Squirrel/SQRLUpdate.m
@@ -7,7 +7,7 @@
 //
 
 #import "SQRLUpdate.h"
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 
 NSString * const SQRLUpdateJSONURLKey = @"url";
 NSString * const SQRLUpdateJSONReleaseNotesKey = @"notes";

--- a/Squirrel/SQRLUpdater.h
+++ b/Squirrel/SQRLUpdater.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 
 // Represents the current state of the updater.
 //

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -18,8 +18,8 @@
 #import "SQRLUpdate.h"
 #import "SQRLZipArchiver.h"
 #import "SQRLShipItRequest.h"
-#import <ReactiveCocoa/EXTScope.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/EXTScope.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 #import <sys/mount.h>
 
 NSString * const SQRLUpdaterErrorDomain = @"SQRLUpdaterErrorDomain";

--- a/Squirrel/SQRLZipArchiver.m
+++ b/Squirrel/SQRLZipArchiver.m
@@ -7,8 +7,8 @@
 //
 
 #import "SQRLZipArchiver.h"
-#import <ReactiveCocoa/EXTScope.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/EXTScope.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 
 NSString * const SQRLZipArchiverErrorDomain = @"SQRLZipArchiverErrorDomain";
 NSString * const SQRLZipArchiverExitCodeErrorKey = @"SQRLZipArchiverExitCodeErrorKey";
@@ -135,7 +135,7 @@ const NSInteger SQRLZipArchiverShellTaskFailed = 1;
 			return [RACSignal
 				zip:@[ self.taskTerminated, self.standardErrorData ]
 				reduce:^(NSNumber *exitStatus, NSData *errorData) {
-					if (exitStatus.intValue == 0) return [RACSignal empty];
+					if (exitStatus.intValue == 0) return [RACSignal return:self];
 
 					NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
 					userInfo[SQRLZipArchiverExitCodeErrorKey] = exitStatus;

--- a/Squirrel/ShipIt-main.m
+++ b/Squirrel/ShipIt-main.m
@@ -8,10 +8,10 @@
 
 #import <Foundation/Foundation.h>
 
-#import "EXTScope.h"
-#import <ReactiveCocoa/RACCommand.h>
-#import <ReactiveCocoa/RACSignal+Operations.h>
-#import <ReactiveCocoa/RACScheduler.h>
+#import <ReactiveObjC/EXTScope.h>
+#import <ReactiveObjC/RACCommand.h>
+#import <ReactiveObjC/RACSignal+Operations.h>
+#import <ReactiveObjC/RACScheduler.h>
 
 #import "NSError+SQRLVerbosityExtensions.h"
 #import "RACSignal+SQRLTransactionExtensions.h"

--- a/SquirrelTests/NSProcessInfoExtensionsSpec.m
+++ b/SquirrelTests/NSProcessInfoExtensionsSpec.m
@@ -8,7 +8,7 @@
 
 #import <Nimble/Nimble.h>
 #import <Quick/Quick.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 #import <Squirrel/Squirrel.h>
 
 QuickSpecBegin(NSProcessInfoExtensions)

--- a/SquirrelTests/QuickSpec+SQRLFixtures.h
+++ b/SquirrelTests/QuickSpec+SQRLFixtures.h
@@ -8,7 +8,7 @@
 
 #import <Nimble/Nimble.h>
 #import <Quick/Quick.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 #import <Squirrel/Squirrel.h>
 
 /// See https://github.com/Squirrel/Squirrel.Mac/pull/154#issuecomment-151287744

--- a/SquirrelTests/SQRLCodeSignatureSpec.m
+++ b/SquirrelTests/SQRLCodeSignatureSpec.m
@@ -8,7 +8,7 @@
 
 #import <Nimble/Nimble.h>
 #import <Quick/Quick.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 #import <Squirrel/Squirrel.h>
 
 #import "SQRLCodeSignature.h"

--- a/SquirrelTests/SQRLDirectoryManagerSpec.m
+++ b/SquirrelTests/SQRLDirectoryManagerSpec.m
@@ -8,7 +8,7 @@
 
 #import <Nimble/Nimble.h>
 #import <Quick/Quick.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 #import <Squirrel/Squirrel.h>
 
 #import "SQRLDirectoryManager.h"

--- a/SquirrelTests/SQRLInstallerSpec.m
+++ b/SquirrelTests/SQRLInstallerSpec.m
@@ -8,7 +8,7 @@
 
 #import <Nimble/Nimble.h>
 #import <Quick/Quick.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 #import <Squirrel/Squirrel.h>
 
 #import "SQRLCodeSignature.h"

--- a/SquirrelTests/SQRLShipItRequestSpec.m
+++ b/SquirrelTests/SQRLShipItRequestSpec.m
@@ -8,7 +8,7 @@
 
 #import <Nimble/Nimble.h>
 #import <Quick/Quick.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 #import <Squirrel/Squirrel.h>
 
 #import "SQRLDirectoryManager.h"

--- a/SquirrelTests/SQRLTerminationListenerSpec.m
+++ b/SquirrelTests/SQRLTerminationListenerSpec.m
@@ -8,7 +8,7 @@
 
 #import <Nimble/Nimble.h>
 #import <Quick/Quick.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 #import <Squirrel/Squirrel.h>
 
 #import "SQRLTerminationListener.h"

--- a/SquirrelTests/SQRLUpdateSpec.m
+++ b/SquirrelTests/SQRLUpdateSpec.m
@@ -8,7 +8,7 @@
 
 #import <Nimble/Nimble.h>
 #import <Quick/Quick.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 #import <Squirrel/Squirrel.h>
 
 QuickSpecBegin(SQRLUpdateSpec)

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -8,7 +8,7 @@
 
 #import <Nimble/Nimble.h>
 #import <Quick/Quick.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 #import <Squirrel/Squirrel.h>
 
 #import "SQRLDirectoryManager.h"

--- a/SquirrelTests/SQRLZipArchiverSpec.m
+++ b/SquirrelTests/SQRLZipArchiverSpec.m
@@ -8,7 +8,7 @@
 
 #import <Nimble/Nimble.h>
 #import <Quick/Quick.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 #import <Squirrel/Squirrel.h>
 
 #import "QuickSpec+SQRLFixtures.h"

--- a/TestApplication/TestAppDelegate.m
+++ b/TestApplication/TestAppDelegate.m
@@ -10,8 +10,8 @@
 #import "SQRLDirectoryManager.h"
 #import "SQRLShipItLauncher.h"
 #import "SQRLTestUpdate.h"
-#import <ReactiveCocoa/EXTScope.h>
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import <ReactiveObjC/EXTScope.h>
+#import <ReactiveObjC/ReactiveObjC.h>
 #import "TestAppConstants.h"
 
 @interface TestAppDelegate ()
@@ -106,7 +106,7 @@
 			NSString *delayString = NSProcessInfo.processInfo.environment[@"SQRLUpdateDelay"];
 			if (delayString == nil) return [RACSignal empty];
 
-			return [[RACSignal interval:delayString.doubleValue onScheduler:RACScheduler.mainThreadScheduler] take:1];
+			return (RACSignal *)[[RACSignal interval:delayString.doubleValue onScheduler:RACScheduler.mainThreadScheduler] take:1];
 		}]
 		subscribeCompleted:^{
 			[NSApp terminate:self];

--- a/script/test
+++ b/script/test
@@ -5,9 +5,10 @@ set -eo pipefail
 SCRIPT_DIR=$(dirname "$0")
 cd "$SCRIPT_DIR/.."
 
-# The dependency projects (ReactiveCocoa, Mantle, etc.) ship with their own
-# xcconfigs that enable -Werror and target ancient macOS. Override at the
-# command line so they apply workspace-wide.
+# The dependency projects (ReactiveObjC, Mantle, etc.) ship with their own
+# xcconfigs that enable -Werror, target ancient macOS, and Mantle's Debug
+# config sets --digest-algorithm=sha1. Override at the command line so they
+# apply workspace-wide.
 exec xcodebuild \
   -workspace Squirrel.xcworkspace \
   -scheme Squirrel \
@@ -19,4 +20,5 @@ exec xcodebuild \
   DEVELOPMENT_TEAM= \
   ONLY_ACTIVE_ARCH=YES \
   VALID_ARCHS="arm64 x86_64" \
+  OTHER_CODE_SIGN_FLAGS=--timestamp=none \
   "$@"


### PR DESCRIPTION
Swap the 2015-era Carthage pins for the exact deps Electron builds against (`DEPS`):

| | before | after |
|---|---|---|
| Reactive | ReactiveCocoa v2.5 (`32364b9`) | **ReactiveObjC** @ `74ab5ba` |
| Mantle | 1.5.8 (`78d3966`) | `2a8e212` (≈2.2.0+19) |

#### Project / workspace
- `Carthage/Checkouts/ReactiveCocoa` submodule removed → `ReactiveObjC` added
- Mantle submodule bumped
- `ReactiveCocoa.framework` → `ReactiveObjC.framework` everywhere in pbxproj
- ShipIt target now links `Mantle.framework` + `ReactiveObjC.framework` instead of inline-compiling 60+ vendor `.m` files (drops the `mtl_*=rac_*` symbol-aliasing hack)
- 59+59 dangling `PBXBuildFile`/`PBXFileReference` entries scrubbed

#### Source
- `<ReactiveCocoa/X.h>` → `<ReactiveObjC/X.h>` across `Squirrel/`, `SquirrelTests/`, `TestApplication/`
- `SQRLShipItRequest.m`: `+JSONKeyPathsByPropertyKey` lists all properties (Mantle 2 requires explicit — port of Electron's `fix_add_explicit_json_property_mappings_for_shipit_request_model.patch`)
- `SQRLZipArchiver.m`: success path returns `[RACSignal return:self]` so ARC doesn't dealloc the archiver before NSTask fires (port of Electron's `fix_ensure_that_self_is_retained_until_the_racsignal_is_complete.patch` — required under ReactiveObjC + modern clang)
- `TestAppDelegate.m`: `(RACSignal *)` cast for ReactiveObjC generics

#### Build
- `OTHER_CODE_SIGN_FLAGS=--timestamp=none` in `script/test` + workflow (Mantle 2's vendored xcconfigs set `--digest-algorithm=sha1` which modern codesign rejects)

56/56 tests pass.

> [!NOTE]
> Once Electron bumps `squirrel.mac_version` past this commit, `fix_add_explicit_json_property_mappings…`, `fix_ensure_that_self_is_retained…`, and the import-rewrite hunks in `build_add_gn_config.patch` become no-ops in `electron/patches/squirrel.mac/`.