### PR TITLE
ci: build and test across the full GitHub-hosted macOS / Xcode matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,66 @@ concurrency:
 
 jobs:
   test:
-    name: Build & Test
-    runs-on: macos-latest
+    name: Build & Test (${{ matrix.os }}, Xcode ${{ matrix.xcode }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macos-14 (arm64)
+          - { os: macos-14, xcode: '15.0' }
+          - { os: macos-14, xcode: '15.1' }
+          - { os: macos-14, xcode: '15.2' }
+          - { os: macos-14, xcode: '15.3' }
+          - { os: macos-14, xcode: '15.4' }
+          - { os: macos-14, xcode: '16.1' }
+          - { os: macos-14, xcode: '16.2' }
+          # macos-15 (arm64)
+          - { os: macos-15, xcode: '16.0' }
+          - { os: macos-15, xcode: '16.1' }
+          - { os: macos-15, xcode: '16.2' }
+          - { os: macos-15, xcode: '16.3' }
+          - { os: macos-15, xcode: '16.4' }
+          - { os: macos-15, xcode: '26.0' }
+          - { os: macos-15, xcode: '26.1' }
+          - { os: macos-15, xcode: '26.2' }
+          - { os: macos-15, xcode: '26.3' }
+          # macos-15-intel (x86_64)
+          - { os: macos-15-intel, xcode: '16.0' }
+          - { os: macos-15-intel, xcode: '16.1' }
+          - { os: macos-15-intel, xcode: '16.2' }
+          - { os: macos-15-intel, xcode: '16.3' }
+          - { os: macos-15-intel, xcode: '16.4' }
+          - { os: macos-15-intel, xcode: '26.0' }
+          - { os: macos-15-intel, xcode: '26.1' }
+          - { os: macos-15-intel, xcode: '26.2' }
+          - { os: macos-15-intel, xcode: '26.3' }
+          # macos-26 (arm64)
+          - { os: macos-26, xcode: '26.0' }
+          - { os: macos-26, xcode: '26.1' }
+          - { os: macos-26, xcode: '26.2' }
+          - { os: macos-26, xcode: '26.3' }
+          - { os: macos-26, xcode: '26.4' }
+          # macos-26-intel (x86_64)
+          - { os: macos-26-intel, xcode: '26.0' }
+          - { os: macos-26-intel, xcode: '26.1' }
+          - { os: macos-26-intel, xcode: '26.2' }
+          - { os: macos-26-intel, xcode: '26.3' }
+          - { os: macos-26-intel, xcode: '26.4' }
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
 
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -s "/Applications/Xcode_${{ matrix.xcode }}.app"
+          xcodebuild -version
+
       - name: Build
         run: |
+          set -o pipefail
           xcodebuild \
             -workspace Squirrel.xcworkspace \
             -scheme Squirrel \
@@ -37,8 +87,10 @@ jobs:
             ONLY_ACTIVE_ARCH=YES \
             VALID_ARCHS="arm64 x86_64" \
             OTHER_CODE_SIGN_FLAGS=--timestamp=none \
-            | xcbeautify --renderer github-actions && exit ${PIPESTATUS[0]}
+            | xcbeautify --renderer github-actions
 
       - name: Test
         run: |
-          script/test | xcbeautify --renderer github-actions && exit ${PIPESTATUS[0]}
+          set -o pipefail
+          # shellcheck disable=SC2266 # script/test is a path, not the `test` builtin
+          script/test | xcbeautify --renderer github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,15 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Patch ReactiveObjC for arm64
-        # ReactiveObjC's nested xcconfigs pin VALID_ARCHS = x86_64; some Xcode
-        # versions resolve destinations from project files (CLI overrides do
-        # not apply yet) and refuse arch=arm64.
+      - name: Patch vendored xcconfigs for arm64
+        # The vendored xcconfigs (jspahrsummers/xcconfigs 0.x) pin
+        # VALID_ARCHS = x86_64 in Mac-Base.xcconfig. Project-level
+        # overrides handle the build, but some Xcode versions resolve
+        # -destination from the raw xcconfig before overrides apply and
+        # refuse arch=arm64. Patch every copy under Carthage in place.
         run: |
-          sed -i '' 's/^VALID_ARCHS = x86_64$/VALID_ARCHS = arm64 x86_64/' \
-            "Carthage/Checkouts/ReactiveObjC/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-Base.xcconfig"
+          find Carthage -name 'Mac-Base.xcconfig' -print0 | \
+            xargs -0 sed -i '' 's/^VALID_ARCHS = x86_64$/VALID_ARCHS = arm64 x86_64/'
 
       - name: Select Xcode
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,46 +20,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Latest minor of each major Xcode per runner image
         include:
           # macos-14 (arm64)
-          - { os: macos-14, xcode: '15.0' }
-          - { os: macos-14, xcode: '15.1' }
-          - { os: macos-14, xcode: '15.2' }
-          - { os: macos-14, xcode: '15.3' }
           - { os: macos-14, xcode: '15.4' }
-          - { os: macos-14, xcode: '16.1' }
           - { os: macos-14, xcode: '16.2' }
           # macos-15 (arm64)
-          - { os: macos-15, xcode: '16.0' }
-          - { os: macos-15, xcode: '16.1' }
-          - { os: macos-15, xcode: '16.2' }
-          - { os: macos-15, xcode: '16.3' }
           - { os: macos-15, xcode: '16.4' }
-          - { os: macos-15, xcode: '26.0' }
-          - { os: macos-15, xcode: '26.1' }
-          - { os: macos-15, xcode: '26.2' }
           - { os: macos-15, xcode: '26.3' }
           # macos-15-intel (x86_64)
-          - { os: macos-15-intel, xcode: '16.0' }
-          - { os: macos-15-intel, xcode: '16.1' }
-          - { os: macos-15-intel, xcode: '16.2' }
-          - { os: macos-15-intel, xcode: '16.3' }
           - { os: macos-15-intel, xcode: '16.4' }
-          - { os: macos-15-intel, xcode: '26.0' }
-          - { os: macos-15-intel, xcode: '26.1' }
-          - { os: macos-15-intel, xcode: '26.2' }
           - { os: macos-15-intel, xcode: '26.3' }
           # macos-26 (arm64)
-          - { os: macos-26, xcode: '26.0' }
-          - { os: macos-26, xcode: '26.1' }
-          - { os: macos-26, xcode: '26.2' }
-          - { os: macos-26, xcode: '26.3' }
           - { os: macos-26, xcode: '26.4' }
           # macos-26-intel (x86_64)
-          - { os: macos-26-intel, xcode: '26.0' }
-          - { os: macos-26-intel, xcode: '26.1' }
-          - { os: macos-26-intel, xcode: '26.2' }
-          - { os: macos-26-intel, xcode: '26.3' }
           - { os: macos-26-intel, xcode: '26.4' }
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,17 @@ jobs:
           - { os: macos-26-intel, xcode: '26.4' }
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+
+      - name: Patch ReactiveObjC for arm64
+        # ReactiveObjC's nested xcconfigs pin VALID_ARCHS = x86_64; some Xcode
+        # versions resolve destinations from project files (CLI overrides do
+        # not apply yet) and refuse arch=arm64.
+        run: |
+          sed -i '' 's/^VALID_ARCHS = x86_64$/VALID_ARCHS = arm64 x86_64/' \
+            "Carthage/Checkouts/ReactiveObjC/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-Base.xcconfig"
 
       - name: Select Xcode
         run: |
@@ -68,3 +76,15 @@ jobs:
           set -o pipefail
           # shellcheck disable=SC2266 # script/test is a path, not the `test` builtin
           script/test | xcbeautify --renderer github-actions
+
+  ci-green:
+    name: ci-green
+    if: always()
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: All matrix cells succeeded
+        if: needs.test.result != 'success'
+        run: |
+          echo "::error::matrix result was '${{ needs.test.result }}'"
+          exit 1


### PR DESCRIPTION
Expands the single `macos-latest` job to an 8-cell matrix (latest minor of each Xcode major per runner image) so regressions on older or newer toolchains surface in CI.

| Runner | Arch | Xcode |
|---|---|---|
| `macos-14` | arm64 | 15.4, 16.2 |
| `macos-15` | arm64 | 16.4, 26.3 |
| `macos-15-intel` | x86_64 | 16.4, 26.3 |
| `macos-26` | arm64 | 26.4 |
| `macos-26-intel` | x86_64 | 26.4 |

Explicit `include`-only matrix (no cross-product, since Xcode availability differs per image). `fail-fast: false`. Xcode selected via `sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app` — every listed version has a major.minor symlink per the runner-image readmes.

Sourced from `actions/runner-images` README + per-image readme tables.

#### Excluded
- `macos-14-large` and other `-large`/`-xlarge` labels — paid tier
- Xcode betas — paths roll on every image refresh
- `macos-13` — retired upstream
- Non-latest minors of each major — keep the matrix lean

> [!NOTE]
> `macos-15-intel` / `macos-26-intel` are listed alongside the paid `-large` labels in the runner-images README but without the "larger runner" suffix, so they read as standard-tier. If they turn out to be billed, drop those rows — Intel coverage then falls to zero on free runners.