### PR TITLE
fix: validate nested code with kSecCSCheckNestedCode | kSecCSStrictValidate

### DIFF
--- a/Squirrel/SQRLCodeSignature.m
+++ b/Squirrel/SQRLCodeSignature.m
@@ -124,7 +124,7 @@ const NSInteger SQRLCodeSignatureErrorCouldNotCreateStaticCode = -2;
 		}
 		
 		CFErrorRef validityError = NULL;
-		result = SecStaticCodeCheckValidityWithErrors(staticCode, kSecCSCheckAllArchitectures, (__bridge SecRequirementRef)self.requirement, &validityError);
+		result = SecStaticCodeCheckValidityWithErrors(staticCode, kSecCSCheckNestedCode | kSecCSStrictValidate | kSecCSCheckAllArchitectures, (__bridge SecRequirementRef)self.requirement, &validityError);
 		@onExit {
 			if (validityError != NULL) CFRelease(validityError);
 		};

--- a/SquirrelTests/SQRLCodeSignatureSpec.m
+++ b/SquirrelTests/SQRLCodeSignatureSpec.m
@@ -170,6 +170,47 @@ describe(@"resource changes", ^{
 	});
 });
 
+describe(@"nested code changes", ^{
+	__block NSURL *shipItURL;
+	__block NSURL *frameworkBinaryURL;
+
+	beforeEach(^{
+		shipItURL = [bundle.bundleURL URLByAppendingPathComponent:@"Contents/Frameworks/Squirrel.framework/Versions/A/Resources/ShipIt"];
+		expect(@([NSFileManager.defaultManager fileExistsAtPath:shipItURL.path])).to(beTruthy());
+
+		frameworkBinaryURL = [bundle.bundleURL URLByAppendingPathComponent:@"Contents/Frameworks/Squirrel.framework/Versions/A/Squirrel"];
+		expect(@([NSFileManager.defaultManager fileExistsAtPath:frameworkBinaryURL.path])).to(beTruthy());
+	});
+
+	// kSecCSStrictValidate
+	it(@"should fail to verify when a nested executable is replaced with a symlink", ^{
+		expect(@([NSFileManager.defaultManager removeItemAtURL:shipItURL error:NULL])).to(beTruthy());
+		expect(@([NSFileManager.defaultManager createSymbolicLinkAtURL:shipItURL withDestinationURL:[NSURL fileURLWithPath:@"/bin/ls"] error:NULL])).to(beTruthy());
+
+		NSError *error = nil;
+		BOOL success = [[self.testApplicationSignature verifyBundleAtURL:bundle.bundleURL] waitUntilCompleted:&error];
+		expect(@(success)).to(beFalsy());
+
+		expect(error.domain).to(equal(SQRLCodeSignatureErrorDomain));
+		expect(@(error.code)).to(equal(@(SQRLCodeSignatureErrorDidNotPass)));
+	});
+
+	// kSecCSCheckNestedCode
+	it(@"should fail to verify when a nested framework binary is tampered", ^{
+		NSFileHandle *handle = [NSFileHandle fileHandleForWritingAtPath:frameworkBinaryURL.path];
+		[handle seekToEndOfFile];
+		[handle writeData:[@"corrupt" dataUsingEncoding:NSUTF8StringEncoding]];
+		[handle closeFile];
+
+		NSError *error = nil;
+		BOOL success = [[self.testApplicationSignature verifyBundleAtURL:bundle.bundleURL] waitUntilCompleted:&error];
+		expect(@(success)).to(beFalsy());
+
+		expect(error.domain).to(equal(SQRLCodeSignatureErrorDomain));
+		expect(@(error.code)).to(equal(@(SQRLCodeSignatureErrorDidNotPass)));
+	});
+});
+
 describe(@"framework changes", ^{
 	__block NSURL *frameworkURL;
 


### PR DESCRIPTION
Upstreams `fix_use_kseccschecknestedcode_kseccsstrictvalidate_in_the_sec.patch`. Two new specs: ShipIt-symlink and framework-binary tamper now fail validation.

Independent of the rest of the patch-upstream stack — only touches `SQRLCodeSignature.m` and its spec.

---

Part of upstreaming `electron/patches/squirrel.mac/` into this repo.