### PR TITLE
feat: add SquirrelMacEnableDirectContentsWrite install method behind flag

### DIFF
--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -329,7 +329,12 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 
 			BOOL targetWritable = [self canWriteToURL:targetURL];
 			BOOL parentWritable = [self canWriteToURL:targetURL.URLByDeletingLastPathComponent];
-			return [SQRLShipItLauncher launchPrivileged:!targetWritable || !parentWritable];
+			BOOL launchPrivileged = !targetWritable || !parentWritable;
+			if ([[NSUserDefaults standardUserDefaults] boolForKey:@"SquirrelMacEnableDirectContentsWrite"]) {
+				// If SquirrelMacEnableDirectContentsWrite is enabled we don't care if the parent directory is writeable or not
+				launchPrivileged = !targetWritable;
+			}
+			return [SQRLShipItLauncher launchPrivileged:launchPrivileged];
 		}]
 		replayLazily]
 		setNameWithFormat:@"shipItLauncher"];

--- a/SquirrelTests/SQRLInstallerSpec.m
+++ b/SquirrelTests/SQRLInstallerSpec.m
@@ -19,6 +19,8 @@
 
 #import "QuickSpec+SQRLFixtures.h"
 
+#import <sys/xattr.h>
+
 QuickSpecBegin(SQRLInstallerSpec)
 
 mode_t (^modeOfURL)(NSURL *) = ^ mode_t (NSURL *fileURL) {
@@ -53,6 +55,37 @@ it(@"should install an update in process", ^{
 	[self installWithRequest:request remote:NO];
 
 	expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
+});
+
+describe(@"with SquirrelMacEnableDirectContentsWrite enabled", ^{
+	beforeEach(^{
+		// SQRLInstaller adds the running application's identifier (and that
+		// identifier minus a trailing .ShipIt) as search suites, but
+		// `[[NSUserDefaults alloc] init]` already includes the host app's
+		// domain — so writing via standardUserDefaults is sufficient when
+		// running the installer in-process.
+		[NSUserDefaults.standardUserDefaults setBool:YES forKey:@"SquirrelMacEnableDirectContentsWrite"];
+
+		[self addCleanupBlock:^{
+			[NSUserDefaults.standardUserDefaults removeObjectForKey:@"SquirrelMacEnableDirectContentsWrite"];
+		}];
+	});
+
+	it(@"should install an update by replacing Contents and leave the .app directory itself untouched", ^{
+		const char *xattrName = "com.github.Squirrel.spec-id";
+		NSString *marker = NSProcessInfo.processInfo.globallyUniqueString;
+		expect(@(setxattr(self.testApplicationURL.fileSystemRepresentation, xattrName, marker.UTF8String, strlen(marker.UTF8String), 0, 0))).to(equal(@0));
+
+		SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:updateURL targetBundleURL:self.testApplicationURL bundleIdentifier:nil launchAfterInstallation:NO useUpdateBundleName:NO];
+		[self installWithRequest:request remote:NO];
+
+		expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
+
+		NSMutableData *buf = [NSMutableData dataWithLength:256];
+		ssize_t len = getxattr(self.testApplicationURL.fileSystemRepresentation, xattrName, buf.mutableBytes, buf.length, 0, 0);
+		expect(@(len)).to(beGreaterThan(@0));
+		expect([[NSString alloc] initWithBytes:buf.bytes length:(NSUInteger)len encoding:NSUTF8StringEncoding]).to(equal(marker));
+	});
 });
 
 it(@"should install an update and relaunch", ^{


### PR DESCRIPTION
Upstreams `feat_add_new_squirrel_mac_bundle_installation_method_behind_flag.patch`. New end-to-end spec verifies the parent directory is untouched.

> [!NOTE]
> Fixed a shadowing bug from the original patch in `SQRLUpdater.m` (`BOOL launchPrivileged = !targetWritable` declared a new local that was never used). Should be backported to Electron's patch.

---

Part of upstreaming `electron/patches/squirrel.mac/` into this repo. First in a 6-PR chain (the rest share `SQRLInstaller.m`/`SQRLUpdater.m`/`ShipIt-main.m`).