### PR TITLE
fix: abort install if target app is running; resolve target path once

### DIFF
--- a/Squirrel/SQRLInstaller.h
+++ b/Squirrel/SQRLInstaller.h
@@ -37,6 +37,9 @@ extern const NSInteger SQRLInstallerErrorMovingAcrossVolumes;
 // There was an error changing the file permissions of the update.
 extern const NSInteger SQRLInstallerErrorChangingPermissions;
 
+// There was a running instance of the app just prior to the update attempt
+extern const NSInteger SQRLInstallerErrorAppStillRunning;
+
 @class RACCommand;
 
 // Performs the installation of an update, saving its intermediate state to user

--- a/Squirrel/SQRLInstaller.m
+++ b/Squirrel/SQRLInstaller.m
@@ -9,6 +9,9 @@
 #import "SQRLInstaller.h"
 
 #import <libkern/OSAtomic.h>
+#import <mach-o/dyld.h>
+#import <sys/param.h>
+#import <unistd.h>
 #import <ReactiveObjC/EXTScope.h>
 #import <ReactiveObjC/NSEnumerator+RACSequenceAdditions.h>
 #import <ReactiveObjC/NSObject+RACPropertySubscribing.h>
@@ -36,6 +39,7 @@ const NSInteger SQRLInstallerErrorMissingInstallationData = -5;
 const NSInteger SQRLInstallerErrorInvalidState = -6;
 const NSInteger SQRLInstallerErrorMovingAcrossVolumes = -7;
 const NSInteger SQRLInstallerErrorChangingPermissions = -8;
+const NSInteger SQRLInstallerErrorAppStillRunning = -9;
 
 NSString * const SQRLShipItInstallationAttemptsKey = @"SQRLShipItInstallationAttempts";
 NSString * const SQRLInstallerOwnedBundleKey = @"SQRLInstallerOwnedBundle";
@@ -280,12 +284,70 @@ NSString * const SQRLInstallerOwnedBundleKey = @"SQRLInstallerOwnedBundle";
 - (RACSignal *)installRequest:(SQRLShipItRequest *)request {
 	NSParameterAssert(request != nil);
 
+	// Resolve the target bundle path exactly once and use the canonical URL for
+	// every step of the install chain. The request is read from disk, so the
+	// path it carries is untrusted; every downstream step that re-resolves it
+	// must see the same location that validation saw.
+	NSURL *resolvedTargetURL = request.targetBundleURL.URLByResolvingSymlinksInPath.URLByStandardizingPath;
+	if (![resolvedTargetURL.path isEqual:request.targetBundleURL.URLByStandardizingPath.path]) {
+		NSDictionary *errorInfo = @{
+			NSLocalizedDescriptionKey: NSLocalizedString(@"Target bundle path is not canonical", nil),
+			NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"The target bundle path must not traverse symbolic links.", nil),
+		};
+		return [RACSignal error:[NSError errorWithDomain:SQRLInstallerErrorDomain code:SQRLInstallerErrorInvalidState userInfo:errorInfo]];
+	}
+	request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:request.updateBundleURL targetBundleURL:resolvedTargetURL bundleIdentifier:request.bundleIdentifier launchAfterInstallation:request.launchAfterInstallation useUpdateBundleName:request.useUpdateBundleName];
+
+	// When running privileged, the target must be the app bundle that contains
+	// this installer. This pins the install to a location whose ancestors the
+	// user that wrote the request cannot modify.
+	if (geteuid() == 0) {
+		NSString *expectedTargetPath = nil;
+		char rawPath[PATH_MAX] = {0};
+		char canonicalPath[PATH_MAX] = {0};
+		uint32_t rawPathSize = sizeof(rawPath);
+		if (_NSGetExecutablePath(rawPath, &rawPathSize) == 0 && realpath(rawPath, canonicalPath) != NULL) {
+			NSArray<NSString *> *components = @(canonicalPath).pathComponents;
+			for (NSInteger i = (NSInteger)components.count - 1; i >= 0; i--) {
+				if ([components[(NSUInteger)i] hasSuffix:@".app"]) {
+					NSURL *expectedURL = [NSURL fileURLWithPath:[NSString pathWithComponents:[components subarrayWithRange:NSMakeRange(0, (NSUInteger)i + 1)]]];
+					expectedTargetPath = expectedURL.URLByStandardizingPath.path;
+					break;
+				}
+			}
+		}
+		if (expectedTargetPath == nil || ![resolvedTargetURL.path isEqual:expectedTargetPath]) {
+			NSLog(@"Privileged install rejected: target %@ does not match installer bundle %@", resolvedTargetURL.path, expectedTargetPath);
+			NSDictionary *errorInfo = @{
+				NSLocalizedDescriptionKey: NSLocalizedString(@"Target bundle does not match installer location", nil),
+				NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"When running with elevated privileges, the target bundle must be the application that contains this installer.", nil),
+			};
+			return [RACSignal error:[NSError errorWithDomain:SQRLInstallerErrorDomain code:SQRLInstallerErrorInvalidState userInfo:errorInfo]];
+		}
+	}
+
 	return [[[[self
 		prepareAndValidateUpdateBundleURLForRequest:request]
 		flattenMap:^(NSURL *updateBundleURL) {
 			return [[[[self
 				renameIfNeeded:request updateBundleURL:updateBundleURL]
 				flattenMap:^(SQRLShipItRequest *request) {
+					// Final validation that the application is not running again;
+					NSArray *apps = nil;
+					if (request.bundleIdentifier != nil) {
+						apps = [[NSRunningApplication runningApplicationsWithBundleIdentifier:request.bundleIdentifier] filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSRunningApplication *app, NSDictionary *bindings) {
+							return [[[app bundleURL] URLByStandardizingPath] isEqual:request.targetBundleURL];
+						}]];
+					}
+					if ([apps count] != 0) {
+						NSLog(@"Aborting update attempt because there are %lu running instances of the target app", [apps count]);
+						NSDictionary *errorInfo = @{
+							NSLocalizedDescriptionKey: NSLocalizedString(@"App Still Running Error", nil),
+							NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"All instances of the target application should be quit during the update process", nil),
+						};
+						return [RACSignal error:[NSError errorWithDomain:SQRLInstallerErrorDomain code:SQRLInstallerErrorAppStillRunning userInfo:errorInfo]];
+					}
+
 					return [[self acquireTargetBundleURLForRequest:request] concat:[RACSignal return:request]];
 				}]
 				flattenMap:^(SQRLShipItRequest *request) {

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -325,7 +325,7 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 		defer:^{
 			@strongify(self);
 
-			NSURL *targetURL = NSRunningApplication.currentApplication.bundleURL;
+			NSURL *targetURL = NSRunningApplication.currentApplication.bundleURL.URLByResolvingSymlinksInPath;
 
 			BOOL targetWritable = [self canWriteToURL:targetURL];
 			BOOL parentWritable = [self canWriteToURL:targetURL.URLByDeletingLastPathComponent];
@@ -728,12 +728,13 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 	return [[[[RACSignal
 		defer:^{
 			NSRunningApplication *currentApplication = NSRunningApplication.currentApplication;
-			NSBundle *appBundle = [NSBundle bundleWithURL:currentApplication.bundleURL];
+			NSURL *targetBundleURL = currentApplication.bundleURL.URLByResolvingSymlinksInPath;
+			NSBundle *appBundle = [NSBundle bundleWithURL:targetBundleURL];
 			// Only use the update bundle's name if the user hasn't renamed the
 			// app themselves.
-			BOOL useUpdateBundleName = [appBundle.sqrl_executableName isEqual:currentApplication.bundleURL.lastPathComponent.stringByDeletingPathExtension];
+			BOOL useUpdateBundleName = [appBundle.sqrl_executableName isEqual:targetBundleURL.lastPathComponent.stringByDeletingPathExtension];
 
-			SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:update.bundle.bundleURL targetBundleURL:currentApplication.bundleURL bundleIdentifier:currentApplication.bundleIdentifier launchAfterInstallation:NO useUpdateBundleName:useUpdateBundleName];
+			SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:update.bundle.bundleURL targetBundleURL:targetBundleURL bundleIdentifier:currentApplication.bundleIdentifier launchAfterInstallation:NO useUpdateBundleName:useUpdateBundleName];
 			return [request writeUsingURL:self.shipItStateURL];
 		}]
 		then:^{

--- a/Squirrel/ShipIt-main.m
+++ b/Squirrel/ShipIt-main.m
@@ -158,8 +158,14 @@ static void installRequest(RACSignal *readRequestSignal, NSString *applicationId
 			return action;
 		}]
 		subscribeError:^(NSError *error) {
-			NSLog(@"Installation error: %@", error);
-			exit(EXIT_FAILURE);
+			if ([[error domain] isEqual:SQRLInstallerErrorDomain] && [error code] == SQRLInstallerErrorAppStillRunning) {
+				NSLog(@"Installation cancelled: %@", error);
+				clearInstallationAttempts(applicationIdentifier);
+				exit(EXIT_SUCCESS);
+			} else {
+				NSLog(@"Installation error: %@", error);
+				exit(EXIT_FAILURE);
+			}
 		} completed:^{
 			exit(EXIT_SUCCESS);
 		}];

--- a/SquirrelTests/SQRLInstallerSpec.m
+++ b/SquirrelTests/SQRLInstallerSpec.m
@@ -88,6 +88,38 @@ describe(@"with SquirrelMacEnableDirectContentsWrite enabled", ^{
 	});
 });
 
+it(@"should refuse to install when the target bundle path traverses a symlink", ^{
+	NSURL *symlinkURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:@"symlinked.app"];
+	expect(@([NSFileManager.defaultManager createSymbolicLinkAtURL:symlinkURL withDestinationURL:self.testApplicationURL error:NULL])).to(beTruthy());
+
+	SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:updateURL targetBundleURL:symlinkURL bundleIdentifier:nil launchAfterInstallation:NO useUpdateBundleName:NO];
+
+	SQRLInstaller *installer = [[SQRLInstaller alloc] initWithApplicationIdentifier:self.shipItDirectoryManager.applicationIdentifier];
+	NSError *error = nil;
+	BOOL installed = [[installer.installUpdateCommand execute:request] asynchronouslyWaitUntilCompleted:&error];
+
+	expect(@(installed)).to(beFalsy());
+	expect(error.domain).to(equal(SQRLInstallerErrorDomain));
+	expect(@(error.code)).to(equal(@(SQRLInstallerErrorInvalidState)));
+});
+
+it(@"should abort the install if the target application is still running", ^{
+	NSRunningApplication *app = [self launchTestApplicationWithEnvironment:nil];
+	expect(@(app.isTerminated)).to(beFalsy());
+
+	SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:updateURL targetBundleURL:self.testApplicationURL bundleIdentifier:@"com.github.Squirrel.TestApplication" launchAfterInstallation:NO useUpdateBundleName:NO];
+
+	SQRLInstaller *installer = [[SQRLInstaller alloc] initWithApplicationIdentifier:self.shipItDirectoryManager.applicationIdentifier];
+	NSError *error = nil;
+	BOOL installed = [[installer.installUpdateCommand execute:request] asynchronouslyWaitUntilCompleted:&error];
+
+	expect(@(installed)).to(beFalsy());
+	expect(error.domain).to(equal(SQRLInstallerErrorDomain));
+	expect(@(error.code)).to(equal(@(SQRLInstallerErrorAppStillRunning)));
+
+	expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationOriginalShortVersionString));
+});
+
 it(@"should install an update and relaunch", ^{
 	NSString *bundleIdentifier = @"com.github.Squirrel.TestApplication";
 	NSArray *apps = [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleIdentifier];


### PR DESCRIPTION
Stacked on #303.

Upstreams `fix_abort_installation_attempt_at_the_final_mile_if_the_app_is.patch` + `fix_resolve_target_bundle_path_once_at_start_of_install.patch`. Two new specs (symlink-target rejected, abort-if-running).

> [!NOTE]
> Guarded `runningApplicationsWithBundleIdentifier:` with a nil check (throws on nil; existing fixtures use nil). Should be backported to Electron's patch.

---

Part of upstreaming `electron/patches/squirrel.mac/` into this repo.

Fixes #124.
