### PR TITLE
feat: add ElectronSquirrelPreventDowngrades opt-in flag

### DIFF
--- a/Squirrel/SQRLUpdater.h
+++ b/Squirrel/SQRLUpdater.h
@@ -117,6 +117,10 @@ typedef enum {
 // documentation for more information.
 @property (atomic, strong) Class updateClass;
 
+// Publicly exposed for testing purposes, compares two version strings to see if it's
+// allowed.  This assumes that the ElectronSquirrelPreventDowngrades flag is enabled.
++ (bool) isVersionAllowedForUpdate:(NSString*)targetVersion from:(NSString*)currentVersion;
+
 // Initializes an updater that will send the given request to check for updates.
 //
 // This is the designated initializer for this class.

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -631,4 +631,18 @@ describe(@"state", ^{
 	});
 });
 
+describe(@"+isVersionAllowedForUpdate:from:", ^{
+	it(@"should compare version numbers correctly", ^{
+		expect(@([SQRLUpdater isVersionAllowedForUpdate:@"2.0.0" from:@"1.0.0"])).to(beTruthy());
+		expect(@([SQRLUpdater isVersionAllowedForUpdate:@"1.0.10" from:@"1.0.1"])).to(beTruthy());
+		expect(@([SQRLUpdater isVersionAllowedForUpdate:@"1.0.1" from:@"1.0.10"])).to(beFalsy());
+		expect(@([SQRLUpdater isVersionAllowedForUpdate:@"1.32.0" from:@"1.31.1"])).to(beTruthy());
+		expect(@([SQRLUpdater isVersionAllowedForUpdate:@"0.32.0" from:@"1.31.1"])).to(beFalsy());
+	});
+
+	it(@"should allow updating to the same version", ^{
+		expect(@([SQRLUpdater isVersionAllowedForUpdate:@"1.2.3" from:@"1.2.3"])).to(beTruthy());
+	});
+});
+
 QuickSpecEnd


### PR DESCRIPTION
Stacked on #304.

Upstreams `feat_add_ability_to_prevent_version_downgrades.patch`. Two unit specs for `+isVersionAllowedForUpdate:from:`. The end-to-end "should not update to lower version" cases are punted — flag is read from `NSRunningApplication.currentApplication`'s Info.plist, not unit-reachable.

---

Part of upstreaming `electron/patches/squirrel.mac/` into this repo.