### PR TITLE
refactor: harden how ShipIt is launched and re-launched

### DIFF
--- a/Squirrel/SQRLShipItLauncher.m
+++ b/Squirrel/SQRLShipItLauncher.m
@@ -10,6 +10,7 @@
 #import <ReactiveObjC/EXTScope.h>
 #import "SQRLDirectoryManager.h"
 #import <ReactiveObjC/ReactiveObjC.h>
+#import <xpc/xpc.h>
 #import <Security/Security.h>
 #import <ServiceManagement/ServiceManagement.h>
 #import <launch.h>
@@ -57,7 +58,7 @@ const NSInteger SQRLShipItLauncherErrorCouldNotStartService = 1;
 			NSMutableArray *arguments = [[NSMutableArray alloc] init];
 			[arguments addObject:[squirrelBundle URLForResource:@"ShipIt" withExtension:nil].path];
 
-			// Pass in the service name so ShipIt knows how to broadcast itself.
+			// Pass in the job label so ShipIt can identify itself.
 			[arguments addObject:jobLabel];
 
 			// We need to pass the path to ShipIt rather than having ShipIt
@@ -152,6 +153,23 @@ const NSInteger SQRLShipItLauncherErrorCouldNotStartService = 1;
 
 			if (!SMJobSubmit(domain, (__bridge CFDictionaryRef)jobDictionary, authorization, &cfError)) {
 				return [RACSignal error:CFBridgingRelease(cfError)];
+			}
+
+			// Trigger an on-demand launch by sending a message to the job's
+			// Mach service. When loginwindow begins a restart (e.g. for a
+			// pending macOS update) it puts the per-user launchd domain into
+			// on-demand-only mode, which defers RunAtLoad/KeepAlive spawns
+			// but still honors real IPC demand. The system domain is not
+			// affected, so this is only needed for the unprivileged path.
+			if (!privileged) {
+				xpc_connection_t trigger = xpc_connection_create_mach_service(self.shipItJobLabel.UTF8String, NULL, 0);
+				xpc_connection_set_event_handler(trigger, ^(xpc_object_t __unused event) {});
+				xpc_connection_resume(trigger);
+				xpc_connection_send_message(trigger, xpc_dictionary_create(NULL, NULL, 0));
+				// send_message is async; keep the connection alive until the
+				// message is actually on the wire so ARC releasing `trigger`
+				// at end-of-scope can't drop it first.
+				xpc_connection_send_barrier(trigger, ^{ (void)trigger; });
 			}
 
 			return [RACSignal empty];

--- a/Squirrel/ShipIt-main.m
+++ b/Squirrel/ShipIt-main.m
@@ -13,12 +13,31 @@
 #import <ReactiveObjC/RACSignal+Operations.h>
 #import <ReactiveObjC/RACScheduler.h>
 
+#include <spawn.h>
+#include <sys/wait.h>
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
 #import "NSError+SQRLVerbosityExtensions.h"
 #import "RACSignal+SQRLTransactionExtensions.h"
 #import "SQRLInstaller.h"
 #import "SQRLInstaller+Private.h"
 #import "SQRLTerminationListener.h"
 #import "SQRLShipItRequest.h"
+
+extern char **environ;
+
+int responsibility_spawnattrs_setdisclaim(posix_spawnattr_t attrs, int disclaim)
+__attribute__((availability(macos,introduced=10.14),weak_import));
+
+#define CHECK_ERR(expr) \
+	{ \
+		int err = (expr); \
+    if (err) { \
+        fprintf(stderr, "%s: %s", #expr, strerror(err)); \
+        exit(err); \
+    } \
+	}
 
 // The maximum number of times ShipIt should run the same installation state, in
 // an attempt to update.
@@ -44,6 +63,28 @@ static BOOL setInstallationAttempts(NSString *applicationIdentifier, NSUInteger 
 static BOOL clearInstallationAttempts(NSString *applicationIdentifier) {
 	CFPreferencesSetValue((__bridge CFStringRef)SQRLShipItInstallationAttemptsKey, NULL, (__bridge CFStringRef)applicationIdentifier, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
 	return CFPreferencesSynchronize((__bridge CFStringRef)applicationIdentifier, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
+}
+
+// Drain the Mach service port registered via MachServices in the launchd
+// job dictionary before exit(0) so launchd sees no outstanding demand and
+// does not immediately respawn the job. bootstrap_check_in transfers the
+// receive right into this task, but that alone is not sufficient: launchd
+// tracks demand independently of the port's lifetime, so the queued
+// trigger message must be explicitly dequeued. On failure exits the
+// message is intentionally left queued so the KeepAlive respawn is
+// demand-backed while the launchd domain is in on-demand-only mode.
+static void drainMachServicePort(const char *serviceName) {
+	mach_port_t port = MACH_PORT_NULL;
+	if (bootstrap_check_in(bootstrap_port, serviceName, &port) != KERN_SUCCESS) return;
+
+	struct {
+		mach_msg_header_t header;
+		uint8_t body[4096];
+	} msg;
+	while (mach_msg(&msg.header, MACH_RCV_MSG | MACH_RCV_TIMEOUT,
+	                0, sizeof(msg), port, 0, MACH_PORT_NULL) == KERN_SUCCESS) {
+		mach_msg_destroy(&msg.header);
+	}
 }
 
 // Waits for all instances of the target application (as described in the
@@ -136,19 +177,47 @@ static void installRequest(RACSignal *readRequestSignal, NSString *applicationId
 							NSString *exe = NSProcessInfo.processInfo.arguments[0];
 							NSLog(@"Launching new ShipIt at %@ with instructions to launch %@", exe, bundleURL);
 
-							NSTask *task = [[NSTask alloc] init];
-							[task setLaunchPath: exe];
-							[task setArguments: @[launchSignal, bundleURL.path]];
-							[task launch];
-							[task waitUntilExit];
+							posix_spawnattr_t attr;
+							CHECK_ERR(posix_spawnattr_init(&attr));
+
+							// Disclaim TCC responsibilities
+							if (responsibility_spawnattrs_setdisclaim)
+									CHECK_ERR(responsibility_spawnattrs_setdisclaim(&attr, 1));
+
+							pid_t pid = 0;
+
+							const char* launchPath = [exe fileSystemRepresentation];
+							const char* signal = [launchSignal fileSystemRepresentation];
+							const char* path = [bundleURL.path fileSystemRepresentation];
+							const char* args[] = { launchPath, signal, path, 0 };
+							int status = posix_spawn(&pid, [exe UTF8String], NULL, &attr, (char *const*)args, environ);
+							if (status == 0) {
+								NSLog(@"New ShipIt pid: %i", pid);
+								do {
+									if (waitpid(pid, &status, 0) != -1) {
+										NSLog(@"ShipIt status %d", WEXITSTATUS(status));
+									} else {
+										perror("waitpid");
+										exit(1);
+									}
+								} while (!WIFEXITED(status) && !WIFSIGNALED(status));
+							} else {
+								NSLog(@"posix_spawn: %s", strerror(status));
+							}
+
+							posix_spawnattr_destroy(&attr);
 
 							NSLog(@"New ShipIt exited");
 						} else {
 							NSLog(@"Attempting to launch app on lower than 11.0");
+// TODO: https://github.com/electron/electron/issues/43168
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 							if (![NSWorkspace.sharedWorkspace launchApplicationAtURL:bundleURL options:NSWorkspaceLaunchDefault configuration:@{} error:&error]) {
 								NSLog(@"Could not launch application at %@: %@", bundleURL, error);
 								return;
 							}
+#pragma clang diagnostic pop
 
 							NSLog(@"Application launched at %@", bundleURL);
 						}
@@ -161,12 +230,14 @@ static void installRequest(RACSignal *readRequestSignal, NSString *applicationId
 			if ([[error domain] isEqual:SQRLInstallerErrorDomain] && [error code] == SQRLInstallerErrorAppStillRunning) {
 				NSLog(@"Installation cancelled: %@", error);
 				clearInstallationAttempts(applicationIdentifier);
+				drainMachServicePort(applicationIdentifier.UTF8String);
 				exit(EXIT_SUCCESS);
 			} else {
 				NSLog(@"Installation error: %@", error);
 				exit(EXIT_FAILURE);
 			}
 		} completed:^{
+			drainMachServicePort(applicationIdentifier.UTF8String);
 			exit(EXIT_SUCCESS);
 		}];
 }
@@ -178,7 +249,13 @@ int main(int argc, const char * argv[]) {
 		});
 
 		if (argc < 3) {
-			NSLog(@"Missing launchd job label or state path for ShipIt");
+			NSLog(@"Missing launchd job label or state path for ShipIt (%d)", argc);
+			if (argc >= 1) {
+				NSLog(@"Arg 1: {%s}", argv[0]);
+			}
+			if (argc >= 2) {
+				NSLog(@"Arg 2: {%s}", argv[1]);
+			}
 			return EXIT_FAILURE;
 		}
 
@@ -188,12 +265,16 @@ int main(int argc, const char * argv[]) {
 
 		if (strcmp(jobLabel, [launchSignal UTF8String]) == 0) {
 			NSLog(@"Detected this as a launch request");
+// TODO: https://github.com/electron/electron/issues/43168
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 			NSError *error;
 			if (![NSWorkspace.sharedWorkspace launchApplicationAtURL:shipItStateURL options:NSWorkspaceLaunchDefault configuration:@{} error:&error]) {
 				NSLog(@"Could not launch application at %@: %@", shipItStateURL, error);
 			} else {
 				NSLog(@"Successfully launched application at %@", shipItStateURL);
 			}
+#pragma clang diagnostic pop
 			exit(EXIT_SUCCESS);
 		} else {
 			NSLog(@"Detected this as an install request");


### PR DESCRIPTION
Stacked on #305.

Upstreams `refactor_use_posix_spawn_instead_of_nstask_so_we_can_disclaim_the.patch` + `fix_trigger_shipit_mach_service_after_smjobsubmit_to_unblock.patch` + `chore_turn_off_launchapplicationaturl_deprecation_errors_in_squirrel.patch`. No new specs — launchd/TCC/mach not unit-reachable; existing remote-ShipIt `SQRLInstallerSpec` exercises the new posix_spawn path.

---

Part of upstreaming `electron/patches/squirrel.mac/` into this repo.

Fixes #196.
