### PR TITLE
refactor: use non-deprecated NSKeyedArchiver APIs

### DIFF
--- a/Squirrel/SQRLInstaller.m
+++ b/Squirrel/SQRLInstaller.m
@@ -185,14 +185,40 @@ NSString * const SQRLInstallerOwnedBundleKey = @"SQRLInstallerOwnedBundle";
 	id archiveData = CFBridgingRelease(CFPreferencesCopyValue((__bridge CFStringRef)SQRLInstallerOwnedBundleKey, (__bridge CFStringRef)self.applicationIdentifier, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost));
 	if (![archiveData isKindOfClass:NSData.class]) return nil;
 
-	SQRLInstallerOwnedBundle *ownedBundle = [NSKeyedUnarchiver unarchiveObjectWithData:archiveData];
-	if (![ownedBundle isKindOfClass:SQRLInstallerOwnedBundle.class]) return nil;
+	// unarchivedObjectOfClass:fromData:error: sets secureCoding to true and we don't
+	// archive data with secureCoding enabled - use our own unarchiver to work around that.
+	NSError *error;
+	NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:archiveData
+                                                                              error:&error];
+	unarchiver.requiresSecureCoding = NO;
+	SQRLInstallerOwnedBundle *ownedBundle = [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
+	[unarchiver finishDecoding];
+
+	if (error) {
+		NSLog(@"Error while unarchiving ownedBundle - %@", error.localizedDescription);
+		return nil;
+	}
+
+	if (!ownedBundle || ![ownedBundle isKindOfClass:SQRLInstallerOwnedBundle.class]) {
+		NSLog(@"Unknown error while unarchiving ownedBundle - did not conform to SQRLInstallerOwnedBundle");
+		return nil;
+	}
 
 	return ownedBundle;
 }
 
 - (void)setOwnedBundle:(SQRLInstallerOwnedBundle *)ownedBundle {
-	NSData *archiveData = (ownedBundle == nil ? nil : [NSKeyedArchiver archivedDataWithRootObject:ownedBundle]);
+	NSData *archiveData = nil;
+	if (ownedBundle != nil) {
+		NSError *error;
+		archiveData = [NSKeyedArchiver archivedDataWithRootObject:ownedBundle
+													requiringSecureCoding:NO
+																					error:&error];
+
+		if (error)
+			NSLog(@"Couldn't archive ownedBundle - %@", error.localizedDescription);
+	}
+
 	CFPreferencesSetValue((__bridge CFStringRef)SQRLInstallerOwnedBundleKey, (__bridge CFPropertyListRef)archiveData, (__bridge CFStringRef)self.applicationIdentifier, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
 	CFPreferencesSynchronize((__bridge CFStringRef)self.applicationIdentifier, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
 }

--- a/SquirrelTests/SQRLInstallerSpec.m
+++ b/SquirrelTests/SQRLInstallerSpec.m
@@ -49,6 +49,21 @@ it(@"should install an update using ShipIt", ^{
 	expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
 });
 
+it(@"should round-trip the owned bundle through CFPreferences", ^{
+	SQRLInstaller *installer = [[SQRLInstaller alloc] initWithApplicationIdentifier:self.shipItDirectoryManager.applicationIdentifier];
+	SQRLInstallerOwnedBundle *original = [[SQRLInstallerOwnedBundle alloc] initWithOriginalURL:self.testApplicationURL temporaryURL:updateURL codeSignature:self.testApplicationSignature];
+
+	[installer setValue:original forKey:@"ownedBundle"];
+
+	SQRLInstallerOwnedBundle *restored = [installer valueForKey:@"ownedBundle"];
+	expect(restored).notTo(beNil());
+	expect(restored.originalURL).to(equal(original.originalURL));
+	expect(restored.temporaryURL).to(equal(original.temporaryURL));
+
+	[installer setValue:nil forKey:@"ownedBundle"];
+	expect([installer valueForKey:@"ownedBundle"]).to(beNil());
+});
+
 it(@"should install an update in process", ^{
 	SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:updateURL targetBundleURL:self.testApplicationURL bundleIdentifier:nil launchAfterInstallation:NO useUpdateBundleName:NO];
 


### PR DESCRIPTION
Stacked on #306.

Upstreams `refactor_use_non-deprecated_nskeyedarchiver_apis.patch`. New spec round-trips `SQRLInstallerOwnedBundle` through the property accessors.

---

Part of upstreaming `electron/patches/squirrel.mac/` into this repo.