### PR TITLE
fix: error instead of throwing when ditto fails to launch

### DIFF
--- a/Squirrel/SQRLZipArchiver.m
+++ b/Squirrel/SQRLZipArchiver.m
@@ -153,7 +153,17 @@ const NSInteger SQRLZipArchiverShellTaskFailed = 1;
 		setNameWithFormat:@"-launchWithArguments: %@", arguments];
 
 	self.dittoTask.arguments = arguments;
-	[self.dittoTask launch];
+
+	NSError *launchError = nil;
+
+	if (![self.dittoTask launchAndReturnError:&launchError]) {
+		NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+		userInfo[NSLocalizedDescriptionKey] = launchError.localizedDescription;
+
+		NSLog(@"Starting ditto task failed with error: %@", launchError.localizedDescription);
+
+		return [RACSignal error:[NSError errorWithDomain:SQRLZipArchiverErrorDomain code:SQRLZipArchiverShellTaskFailed userInfo:userInfo]];
+	}
 
 	return signal;
 }

--- a/SquirrelTests/SQRLZipArchiverSpec.m
+++ b/SquirrelTests/SQRLZipArchiverSpec.m
@@ -15,6 +15,11 @@
 #import "SQRLCodeSignature.h"
 #import "SQRLZipArchiver.h"
 
+@interface SQRLZipArchiver (SQRLTestingHooks)
+@property (nonatomic, strong, readonly) NSTask *dittoTask;
+- (RACSignal *)launchWithArguments:(NSArray *)arguments;
+@end
+
 QuickSpecBegin(SQRLZipArchiverSpec)
 
 it(@"should extract a zip archive created by the Finder", ^{
@@ -31,6 +36,19 @@ it(@"should extract a zip archive created by the Finder", ^{
 	success = [[self.testApplicationSignature verifyBundleAtURL:extractedAppURL] waitUntilCompleted:&error];
 	expect(@(success)).to(beTruthy());
 	expect(error).to(beNil());
+});
+
+it(@"should error (not throw) when the ditto task fails to launch", ^{
+	SQRLZipArchiver *archiver = [[SQRLZipArchiver alloc] init];
+	archiver.dittoTask.launchPath = [self.temporaryDirectoryURL URLByAppendingPathComponent:@"does-not-exist"].path;
+
+	NSError *error = nil;
+	BOOL success = [[archiver launchWithArguments:@[ @"-xk", @"/nope.zip", self.temporaryDirectoryURL.path ]] asynchronouslyWaitUntilCompleted:&error];
+
+	expect(@(success)).to(beFalsy());
+	expect(error.domain).to(equal(SQRLZipArchiverErrorDomain));
+	expect(@(error.code)).to(equal(@(SQRLZipArchiverShellTaskFailed)));
+	expect(error.userInfo[NSLocalizedDescriptionKey]).notTo(beNil());
 });
 
 it(@"should fail to extract a nonexistent zip archive", ^{


### PR DESCRIPTION
Upstreams `fix_crash_when_process_to_extract_zip_cannot_be_launched.patch`. New spec re-points the ditto launch path to force a launch failure and asserts the signal errors instead of throwing.

---

Part of upstreaming `electron/patches/squirrel.mac/` into this repo.