### PR TITLE
fix: prune orphaned staged updates before downloading a new one

### DIFF
--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -542,11 +542,19 @@ BOOL isVersionStandard(NSString* version) {
 #pragma mark File Management
 
 - (RACSignal *)uniqueTemporaryDirectoryForUpdate {
-	return [[[RACSignal
+	// Clean up any orphaned update directories before creating a new one.
+	// This prevents disk usage from growing when checkForUpdates() is called
+	// multiple times without the app restarting. The currently staged update
+	// (referenced by ShipItState.plist) is always preserved so quitAndInstall
+	// remains safe to call while a new check is in progress.
+	return [[[[[self
+		pruneOrphanedUpdateDirectories]
+		ignoreValues]
+		concat:[RACSignal
 		defer:^{
 			SQRLDirectoryManager *directoryManager = [[SQRLDirectoryManager alloc] initWithApplicationIdentifier:SQRLShipItLauncher.shipItJobLabel];
 			return [directoryManager storageURL];
-		}]
+		}]]
 		flattenMap:^(NSURL *storageURL) {
 			NSURL *updateDirectoryTemplate = [storageURL URLByAppendingPathComponent:[SQRLUpdaterUniqueTemporaryDirectoryPrefix stringByAppendingString:@"XXXXXXX"]];
 			char *updateDirectoryCString = strdup(updateDirectoryTemplate.path.fileSystemRepresentation);
@@ -666,25 +674,68 @@ BOOL isVersionStandard(NSString* version) {
 			return [directoryManager storageURL];
 		}]
 		flattenMap:^(NSURL *storageURL) {
-			NSFileManager *manager = [[NSFileManager alloc] init];
-			NSDirectoryEnumerator *enumerator = [manager enumeratorAtURL:storageURL includingPropertiesForKeys:nil options:NSDirectoryEnumerationSkipsSubdirectoryDescendants errorHandler:^(NSURL *URL, NSError *error) {
-				NSLog(@"Error enumerating item %@ within directory %@: %@", URL, storageURL, error);
-				return YES;
-			}];
-
-			return [[enumerator.rac_sequence.signal
-				filter:^(NSURL *enumeratedURL) {
-					NSString *name = enumeratedURL.lastPathComponent;
-					return [name hasPrefix:SQRLUpdaterUniqueTemporaryDirectoryPrefix];
-				}]
-				doNext:^(NSURL *directoryURL) {
-					NSError *error = nil;
-					if (![manager removeItemAtURL:directoryURL error:&error]) {
-						NSLog(@"Error removing old update directory at %@: %@", directoryURL, error.sqrl_verboseDescription);
-					}
-				}];
+			return [self removeUpdateDirectoriesInStorageURL:storageURL excludingURL:nil];
 		}]
 		setNameWithFormat:@"%@ -prunedUpdateDirectories", self];
+}
+
+/// Lazily removes orphaned temporary directories upon subscription, always
+/// preserving the directory currently referenced by ShipItState.plist so that
+/// quitAndInstall remains safe to call mid-check.
+///
+/// Safe to call in any state. Sends each removed directory then completes on
+/// an unspecified thread. Errors reading the staged request are swallowed
+/// (treated as "nothing staged").
+- (RACSignal *)pruneOrphanedUpdateDirectories {
+	return [[[[[SQRLShipItRequest
+		readUsingURL:self.shipItStateURL]
+		map:^(SQRLShipItRequest *request) {
+			// The request holds the URL to the staged .app bundle; its parent
+			// is the update.XXXXXXX directory we must preserve.
+			return [request.updateBundleURL URLByDeletingLastPathComponent];
+		}]
+		catch:^(NSError *error) {
+			// No staged request (or unreadable) — nothing to preserve.
+			return [RACSignal return:nil];
+		}]
+		flattenMap:^(NSURL *stagedDirectoryURL) {
+			SQRLDirectoryManager *directoryManager = [[SQRLDirectoryManager alloc] initWithApplicationIdentifier:SQRLShipItLauncher.shipItJobLabel];
+			return [[directoryManager storageURL]
+				flattenMap:^(NSURL *storageURL) {
+					return [self removeUpdateDirectoriesInStorageURL:storageURL excludingURL:stagedDirectoryURL];
+				}];
+		}]
+		setNameWithFormat:@"%@ -pruneOrphanedUpdateDirectories", self];
+}
+
+/// Shared enumerate-and-delete logic for update temp directories.
+///
+/// storageURL  - The Squirrel storage root to enumerate. Must not be nil.
+/// excludedURL - Directory to skip (compared by standardized path). May be nil.
+- (RACSignal *)removeUpdateDirectoriesInStorageURL:(NSURL *)storageURL excludingURL:(NSURL *)excludedURL {
+	NSParameterAssert(storageURL != nil);
+
+	NSFileManager *manager = [[NSFileManager alloc] init];
+	NSDirectoryEnumerator *enumerator = [manager enumeratorAtURL:storageURL includingPropertiesForKeys:nil options:NSDirectoryEnumerationSkipsSubdirectoryDescendants errorHandler:^(NSURL *URL, NSError *error) {
+		NSLog(@"Error enumerating item %@ within directory %@: %@", URL, storageURL, error);
+		return YES;
+	}];
+
+	NSString *excludedPath = excludedURL.URLByStandardizingPath.path;
+
+	return [[enumerator.rac_sequence.signal
+		filter:^(NSURL *enumeratedURL) {
+			NSString *name = enumeratedURL.lastPathComponent;
+			if (![name hasPrefix:SQRLUpdaterUniqueTemporaryDirectoryPrefix]) return NO;
+			if (excludedPath != nil && [enumeratedURL.URLByStandardizingPath.path isEqualToString:excludedPath]) return NO;
+			return YES;
+		}]
+		doNext:^(NSURL *directoryURL) {
+			NSError *error = nil;
+			if (![manager removeItemAtURL:directoryURL error:&error]) {
+				NSLog(@"Error removing old update directory at %@: %@", directoryURL, error.sqrl_verboseDescription);
+			}
+		}];
 }
 
 

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -21,6 +21,10 @@
 #import "TestAppConstants.h"
 #import <objc/objc-class.h>
 
+@interface SQRLUpdater (SQRLTestingHooks)
+- (RACSignal *)removeUpdateDirectoriesInStorageURL:(NSURL *)storageURL excludingURL:(NSURL *)excludedURL;
+@end
+
 //! force Updater to believe we are not on readonly, to continue downloading the release
 bool isRunningOnReadOnlyVolumeImp(id self, SEL _cmd)
 {
@@ -459,17 +463,12 @@ describe(@"updating", ^{
 				}];
 		});
 
-		// Disabled: pruneUpdateDirectories intentionally skips while the
-		// updater is in SQRLUpdaterStateAwaitingRelaunch (see 7dffc4b /
-		// Squirrel#174), so the staged update directory is expected to
-		// remain on disk until the next cold update check.
-		xit(@"should remove downloaded archives after updating", ^{
+		it(@"should keep the update directory count bounded across repeated checks", ^{
 			SKIP_IF_RUNNING_ON_TRAVIS
 
 			NSError *error = nil;
 			SQRLTestUpdate *update = [SQRLTestUpdate modelWithDictionary:@{
 				@"updateURL": zipUpdate(updateURL),
-				@"final": @YES
 			} error:&error];
 
 			expect(update).notTo(beNil());
@@ -477,12 +476,45 @@ describe(@"updating", ^{
 
 			writeUpdate(update);
 
-			NSRunningApplication *app = launchWithEnvironment(@{ @"SQRLUpdateRequestCount": @"2" });
+			NSRunningApplication *app = launchWithEnvironment(@{ @"SQRLUpdateRequestCount": @"3" });
 			expect([updateDirectoryURLs toArray]).toEventuallyNot(equal(@[]));
 			expect(@(app.terminated)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
-			expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
 
-			expect([updateDirectoryURLs toArray]).withTimeout(SQRLLongTimeout).toEventually(equal(@[]));
+			// pruneOrphanedUpdateDirectories runs before each download and
+			// preserves only the directory referenced by the current
+			// ShipItState, so after N checks at most 2 directories remain
+			// (the most recently staged + the one created during the final
+			// check).
+			expect(@([[updateDirectoryURLs toArray] count])).to(beLessThanOrEqualTo(@2));
+		});
+
+		it(@"should remove orphaned update directories while preserving the excluded one", ^{
+			NSURL *storageURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:@"prune-storage"];
+			expect(@([NSFileManager.defaultManager createDirectoryAtURL:storageURL withIntermediateDirectories:YES attributes:nil error:NULL])).to(beTruthy());
+
+			NSURL *staged = nil;
+			for (int i = 0; i < 4; i++) {
+				NSURL *dir = [storageURL URLByAppendingPathComponent:[NSString stringWithFormat:@"update.ORPHAN%d", i]];
+				expect(@([NSFileManager.defaultManager createDirectoryAtURL:dir withIntermediateDirectories:YES attributes:nil error:NULL])).to(beTruthy());
+				if (i == 2) staged = dir;
+			}
+			// Non-prefixed directory must be left alone.
+			NSURL *unrelated = [storageURL URLByAppendingPathComponent:@"ShipItState.plist"];
+			[NSData.data writeToURL:unrelated atomically:YES];
+
+			SQRLUpdater *updater = [SQRLUpdater alloc];
+			BOOL ok = [[updater removeUpdateDirectoriesInStorageURL:storageURL excludingURL:staged] asynchronouslyWaitUntilCompleted:NULL];
+			expect(@(ok)).to(beTruthy());
+
+			NSArray *remaining = [NSFileManager.defaultManager contentsOfDirectoryAtURL:storageURL includingPropertiesForKeys:nil options:0 error:NULL];
+			NSPredicate *isUpdateDir = [NSPredicate predicateWithBlock:^BOOL(NSURL *url, NSDictionary *bindings) {
+				return [url.lastPathComponent hasPrefix:@"update."];
+			}];
+			NSArray *remainingUpdateDirs = [remaining filteredArrayUsingPredicate:isUpdateDir];
+
+			expect(@(remainingUpdateDirs.count)).to(equal(@1));
+			expect([remainingUpdateDirs.firstObject lastPathComponent]).to(equal(staged.lastPathComponent));
+			expect(@([NSFileManager.defaultManager fileExistsAtPath:unrelated.path])).to(beTruthy());
 		});
 	});
 });


### PR DESCRIPTION
Stacked on #307.

Upstreams `fix_clean_up_orphaned_staged_updates_before_downloading_new_update.patch`. Two specs (unit test of `removeUpdateDirectoriesInStorageURL:excludingURL:`, end-to-end bounded-count across 3 checks); replaces the previously-`xit`'d prune test. "quitAndInstall while 2nd check in flight" punted — needs more harness than the e2e bound provides.

---

Part of upstreaming `electron/patches/squirrel.mac/` into this repo.