### PR TITLE
test: wait for finishedLaunching before returning from launch helper

### DIFF
--- a/SquirrelTests/QuickSpec+SQRLFixtures.m
+++ b/SquirrelTests/QuickSpec+SQRLFixtures.m
@@ -193,6 +193,13 @@ QuickConfigurationEnd
 	NSRunningApplication *app = [NSWorkspace.sharedWorkspace launchApplicationAtURL:self.testApplicationURL options:NSWorkspaceLaunchWithoutAddingToRecents | NSWorkspaceLaunchWithoutActivation | NSWorkspaceLaunchNewInstance | NSWorkspaceLaunchAndHide configuration:configuration error:&error];
 	XCTAssertNotNil(app, @"Could not launch app at %@: %@", self.testApplicationURL, error);
 
+	// launchApplicationAtURL: is async; on slow hosts the app may not have
+	// checked in with Launch Services yet, so callers that immediately query
+	// runningApplicationsWithBundleIdentifier: see nothing and assume it has
+	// already terminated. Wait for the app to finish launching before
+	// returning so tests observe a stable starting state.
+	expect(@(app.finishedLaunching)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
+
 	[self addCleanupBlock:^{
 		if (!app.terminated) {
 			[app terminate];


### PR DESCRIPTION
Fixes the intermittent `SQRLTerminationListenerSpec` failures the matrix CI surfaced (#305, #306).

`launchApplicationAtURL:` returns immediately while the spawned process is still doing its `NSApplication` startup. `-[SQRLTerminationListener waitForTermination]` then calls `runningApplicationsWithBundleIdentifier:` — if the app hasn't checked in with Launch Services yet, that returns an empty array and the signal completes immediately.

Both observed failure modes are this same window:
- `observedApp == nil` + `completed == YES` from the start (one-instance test)
- `completed` going true after only one of two terminates (multi-instance — listener only saw one app at subscribe time)

Block in the fixture until `app.finishedLaunching` so every caller (these two specs plus the seven `SKIP_IF_RUNNING_ON_TRAVIS`-tagged `SQRLUpdaterSpec` cases) sees a stable starting state.