### PR TITLE
feat: upstream Electron's squirrel.mac patches

### DIFF
--- a/Squirrel/SQRLInstaller.h
+++ b/Squirrel/SQRLInstaller.h
@@ -37,6 +37,9 @@ extern const NSInteger SQRLInstallerErrorMovingAcrossVolumes;
 // There was an error changing the file permissions of the update.
 extern const NSInteger SQRLInstallerErrorChangingPermissions;
 
+// There was a running instance of the app just prior to the update attempt
+extern const NSInteger SQRLInstallerErrorAppStillRunning;
+
 @class RACCommand;
 
 // Performs the installation of an update, saving its intermediate state to user

--- a/Squirrel/SQRLInstaller.m
+++ b/Squirrel/SQRLInstaller.m
@@ -9,6 +9,9 @@
 #import "SQRLInstaller.h"
 
 #import <libkern/OSAtomic.h>
+#import <mach-o/dyld.h>
+#import <sys/param.h>
+#import <unistd.h>
 #import <ReactiveObjC/EXTScope.h>
 #import <ReactiveObjC/NSEnumerator+RACSequenceAdditions.h>
 #import <ReactiveObjC/NSObject+RACPropertySubscribing.h>
@@ -36,6 +39,7 @@ const NSInteger SQRLInstallerErrorMissingInstallationData = -5;
 const NSInteger SQRLInstallerErrorInvalidState = -6;
 const NSInteger SQRLInstallerErrorMovingAcrossVolumes = -7;
 const NSInteger SQRLInstallerErrorChangingPermissions = -8;
+const NSInteger SQRLInstallerErrorAppStillRunning = -9;
 
 NSString * const SQRLShipItInstallationAttemptsKey = @"SQRLShipItInstallationAttempts";
 NSString * const SQRLInstallerOwnedBundleKey = @"SQRLInstallerOwnedBundle";
@@ -280,12 +284,70 @@ NSString * const SQRLInstallerOwnedBundleKey = @"SQRLInstallerOwnedBundle";
 - (RACSignal *)installRequest:(SQRLShipItRequest *)request {
 	NSParameterAssert(request != nil);
 
+	// Resolve the target bundle path exactly once and use the canonical URL for
+	// every step of the install chain. The request is read from disk, so the
+	// path it carries is untrusted; every downstream step that re-resolves it
+	// must see the same location that validation saw.
+	NSURL *resolvedTargetURL = request.targetBundleURL.URLByResolvingSymlinksInPath.URLByStandardizingPath;
+	if (![resolvedTargetURL.path isEqual:request.targetBundleURL.URLByStandardizingPath.path]) {
+		NSDictionary *errorInfo = @{
+			NSLocalizedDescriptionKey: NSLocalizedString(@"Target bundle path is not canonical", nil),
+			NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"The target bundle path must not traverse symbolic links.", nil),
+		};
+		return [RACSignal error:[NSError errorWithDomain:SQRLInstallerErrorDomain code:SQRLInstallerErrorInvalidState userInfo:errorInfo]];
+	}
+	request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:request.updateBundleURL targetBundleURL:resolvedTargetURL bundleIdentifier:request.bundleIdentifier launchAfterInstallation:request.launchAfterInstallation useUpdateBundleName:request.useUpdateBundleName];
+
+	// When running privileged, the target must be the app bundle that contains
+	// this installer. This pins the install to a location whose ancestors the
+	// user that wrote the request cannot modify.
+	if (geteuid() == 0) {
+		NSString *expectedTargetPath = nil;
+		char rawPath[PATH_MAX] = {0};
+		char canonicalPath[PATH_MAX] = {0};
+		uint32_t rawPathSize = sizeof(rawPath);
+		if (_NSGetExecutablePath(rawPath, &rawPathSize) == 0 && realpath(rawPath, canonicalPath) != NULL) {
+			NSArray<NSString *> *components = @(canonicalPath).pathComponents;
+			for (NSInteger i = (NSInteger)components.count - 1; i >= 0; i--) {
+				if ([components[(NSUInteger)i] hasSuffix:@".app"]) {
+					NSURL *expectedURL = [NSURL fileURLWithPath:[NSString pathWithComponents:[components subarrayWithRange:NSMakeRange(0, (NSUInteger)i + 1)]]];
+					expectedTargetPath = expectedURL.URLByStandardizingPath.path;
+					break;
+				}
+			}
+		}
+		if (expectedTargetPath == nil || ![resolvedTargetURL.path isEqual:expectedTargetPath]) {
+			NSLog(@"Privileged install rejected: target %@ does not match installer bundle %@", resolvedTargetURL.path, expectedTargetPath);
+			NSDictionary *errorInfo = @{
+				NSLocalizedDescriptionKey: NSLocalizedString(@"Target bundle does not match installer location", nil),
+				NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"When running with elevated privileges, the target bundle must be the application that contains this installer.", nil),
+			};
+			return [RACSignal error:[NSError errorWithDomain:SQRLInstallerErrorDomain code:SQRLInstallerErrorInvalidState userInfo:errorInfo]];
+		}
+	}
+
 	return [[[[self
 		prepareAndValidateUpdateBundleURLForRequest:request]
 		flattenMap:^(NSURL *updateBundleURL) {
 			return [[[[self
 				renameIfNeeded:request updateBundleURL:updateBundleURL]
 				flattenMap:^(SQRLShipItRequest *request) {
+					// Final validation that the application is not running again;
+					NSArray *apps = nil;
+					if (request.bundleIdentifier != nil) {
+						apps = [[NSRunningApplication runningApplicationsWithBundleIdentifier:request.bundleIdentifier] filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSRunningApplication *app, NSDictionary *bindings) {
+							return [[[app bundleURL] URLByStandardizingPath] isEqual:request.targetBundleURL];
+						}]];
+					}
+					if ([apps count] != 0) {
+						NSLog(@"Aborting update attempt because there are %lu running instances of the target app", [apps count]);
+						NSDictionary *errorInfo = @{
+							NSLocalizedDescriptionKey: NSLocalizedString(@"App Still Running Error", nil),
+							NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"All instances of the target application should be quit during the update process", nil),
+						};
+						return [RACSignal error:[NSError errorWithDomain:SQRLInstallerErrorDomain code:SQRLInstallerErrorAppStillRunning userInfo:errorInfo]];
+					}
+
 					return [[self acquireTargetBundleURLForRequest:request] concat:[RACSignal return:request]];
 				}]
 				flattenMap:^(SQRLShipItRequest *request) {

--- a/Squirrel/SQRLInstaller.m
+++ b/Squirrel/SQRLInstaller.m
@@ -185,14 +185,40 @@ NSString * const SQRLInstallerOwnedBundleKey = @"SQRLInstallerOwnedBundle";
 	id archiveData = CFBridgingRelease(CFPreferencesCopyValue((__bridge CFStringRef)SQRLInstallerOwnedBundleKey, (__bridge CFStringRef)self.applicationIdentifier, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost));
 	if (![archiveData isKindOfClass:NSData.class]) return nil;
 
-	SQRLInstallerOwnedBundle *ownedBundle = [NSKeyedUnarchiver unarchiveObjectWithData:archiveData];
-	if (![ownedBundle isKindOfClass:SQRLInstallerOwnedBundle.class]) return nil;
+	// unarchivedObjectOfClass:fromData:error: sets secureCoding to true and we don't
+	// archive data with secureCoding enabled - use our own unarchiver to work around that.
+	NSError *error;
+	NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:archiveData
+                                                                              error:&error];
+	unarchiver.requiresSecureCoding = NO;
+	SQRLInstallerOwnedBundle *ownedBundle = [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
+	[unarchiver finishDecoding];
+
+	if (error) {
+		NSLog(@"Error while unarchiving ownedBundle - %@", error.localizedDescription);
+		return nil;
+	}
+
+	if (!ownedBundle || ![ownedBundle isKindOfClass:SQRLInstallerOwnedBundle.class]) {
+		NSLog(@"Unknown error while unarchiving ownedBundle - did not conform to SQRLInstallerOwnedBundle");
+		return nil;
+	}
 
 	return ownedBundle;
 }
 
 - (void)setOwnedBundle:(SQRLInstallerOwnedBundle *)ownedBundle {
-	NSData *archiveData = (ownedBundle == nil ? nil : [NSKeyedArchiver archivedDataWithRootObject:ownedBundle]);
+	NSData *archiveData = nil;
+	if (ownedBundle != nil) {
+		NSError *error;
+		archiveData = [NSKeyedArchiver archivedDataWithRootObject:ownedBundle
+													requiringSecureCoding:NO
+																					error:&error];
+
+		if (error)
+			NSLog(@"Couldn't archive ownedBundle - %@", error.localizedDescription);
+	}
+
 	CFPreferencesSetValue((__bridge CFStringRef)SQRLInstallerOwnedBundleKey, (__bridge CFPropertyListRef)archiveData, (__bridge CFStringRef)self.applicationIdentifier, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
 	CFPreferencesSynchronize((__bridge CFStringRef)self.applicationIdentifier, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
 }

--- a/Squirrel/SQRLShipItLauncher.m
+++ b/Squirrel/SQRLShipItLauncher.m
@@ -10,6 +10,7 @@
 #import <ReactiveObjC/EXTScope.h>
 #import "SQRLDirectoryManager.h"
 #import <ReactiveObjC/ReactiveObjC.h>
+#import <xpc/xpc.h>
 #import <Security/Security.h>
 #import <ServiceManagement/ServiceManagement.h>
 #import <launch.h>
@@ -57,7 +58,7 @@ const NSInteger SQRLShipItLauncherErrorCouldNotStartService = 1;
 			NSMutableArray *arguments = [[NSMutableArray alloc] init];
 			[arguments addObject:[squirrelBundle URLForResource:@"ShipIt" withExtension:nil].path];
 
-			// Pass in the service name so ShipIt knows how to broadcast itself.
+			// Pass in the job label so ShipIt can identify itself.
 			[arguments addObject:jobLabel];
 
 			// We need to pass the path to ShipIt rather than having ShipIt
@@ -152,6 +153,23 @@ const NSInteger SQRLShipItLauncherErrorCouldNotStartService = 1;
 
 			if (!SMJobSubmit(domain, (__bridge CFDictionaryRef)jobDictionary, authorization, &cfError)) {
 				return [RACSignal error:CFBridgingRelease(cfError)];
+			}
+
+			// Trigger an on-demand launch by sending a message to the job's
+			// Mach service. When loginwindow begins a restart (e.g. for a
+			// pending macOS update) it puts the per-user launchd domain into
+			// on-demand-only mode, which defers RunAtLoad/KeepAlive spawns
+			// but still honors real IPC demand. The system domain is not
+			// affected, so this is only needed for the unprivileged path.
+			if (!privileged) {
+				xpc_connection_t trigger = xpc_connection_create_mach_service(self.shipItJobLabel.UTF8String, NULL, 0);
+				xpc_connection_set_event_handler(trigger, ^(xpc_object_t __unused event) {});
+				xpc_connection_resume(trigger);
+				xpc_connection_send_message(trigger, xpc_dictionary_create(NULL, NULL, 0));
+				// send_message is async; keep the connection alive until the
+				// message is actually on the wire so ARC releasing `trigger`
+				// at end-of-scope can't drop it first.
+				xpc_connection_send_barrier(trigger, ^{ (void)trigger; });
 			}
 
 			return [RACSignal empty];

--- a/Squirrel/SQRLUpdater.h
+++ b/Squirrel/SQRLUpdater.h
@@ -117,6 +117,10 @@ typedef enum {
 // documentation for more information.
 @property (atomic, strong) Class updateClass;
 
+// Publicly exposed for testing purposes, compares two version strings to see if it's
+// allowed.  This assumes that the ElectronSquirrelPreventDowngrades flag is enabled.
++ (bool) isVersionAllowedForUpdate:(NSString*)targetVersion from:(NSString*)currentVersion;
+
 // Initializes an updater that will send the given request to check for updates.
 //
 // This is the designated initializer for this class.

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -325,7 +325,7 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 		defer:^{
 			@strongify(self);
 
-			NSURL *targetURL = NSRunningApplication.currentApplication.bundleURL;
+			NSURL *targetURL = NSRunningApplication.currentApplication.bundleURL.URLByResolvingSymlinksInPath;
 
 			BOOL targetWritable = [self canWriteToURL:targetURL];
 			BOOL parentWritable = [self canWriteToURL:targetURL.URLByDeletingLastPathComponent];
@@ -728,12 +728,13 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 	return [[[[RACSignal
 		defer:^{
 			NSRunningApplication *currentApplication = NSRunningApplication.currentApplication;
-			NSBundle *appBundle = [NSBundle bundleWithURL:currentApplication.bundleURL];
+			NSURL *targetBundleURL = currentApplication.bundleURL.URLByResolvingSymlinksInPath;
+			NSBundle *appBundle = [NSBundle bundleWithURL:targetBundleURL];
 			// Only use the update bundle's name if the user hasn't renamed the
 			// app themselves.
-			BOOL useUpdateBundleName = [appBundle.sqrl_executableName isEqual:currentApplication.bundleURL.lastPathComponent.stringByDeletingPathExtension];
+			BOOL useUpdateBundleName = [appBundle.sqrl_executableName isEqual:targetBundleURL.lastPathComponent.stringByDeletingPathExtension];
 
-			SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:update.bundle.bundleURL targetBundleURL:currentApplication.bundleURL bundleIdentifier:currentApplication.bundleIdentifier launchAfterInstallation:NO useUpdateBundleName:useUpdateBundleName];
+			SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:update.bundle.bundleURL targetBundleURL:targetBundleURL bundleIdentifier:currentApplication.bundleIdentifier launchAfterInstallation:NO useUpdateBundleName:useUpdateBundleName];
 			return [request writeUsingURL:self.shipItStateURL];
 		}]
 		then:^{

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -329,7 +329,12 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 
 			BOOL targetWritable = [self canWriteToURL:targetURL];
 			BOOL parentWritable = [self canWriteToURL:targetURL.URLByDeletingLastPathComponent];
-			return [SQRLShipItLauncher launchPrivileged:!targetWritable || !parentWritable];
+			BOOL launchPrivileged = !targetWritable || !parentWritable;
+			if ([[NSUserDefaults standardUserDefaults] boolForKey:@"SquirrelMacEnableDirectContentsWrite"]) {
+				// If SquirrelMacEnableDirectContentsWrite is enabled we don't care if the parent directory is writeable or not
+				launchPrivileged = !targetWritable;
+			}
+			return [SQRLShipItLauncher launchPrivileged:launchPrivileged];
 		}]
 		replayLazily]
 		setNameWithFormat:@"shipItLauncher"];

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -542,11 +542,19 @@ BOOL isVersionStandard(NSString* version) {
 #pragma mark File Management
 
 - (RACSignal *)uniqueTemporaryDirectoryForUpdate {
-	return [[[RACSignal
+	// Clean up any orphaned update directories before creating a new one.
+	// This prevents disk usage from growing when checkForUpdates() is called
+	// multiple times without the app restarting. The currently staged update
+	// (referenced by ShipItState.plist) is always preserved so quitAndInstall
+	// remains safe to call while a new check is in progress.
+	return [[[[[self
+		pruneOrphanedUpdateDirectories]
+		ignoreValues]
+		concat:[RACSignal
 		defer:^{
 			SQRLDirectoryManager *directoryManager = [[SQRLDirectoryManager alloc] initWithApplicationIdentifier:SQRLShipItLauncher.shipItJobLabel];
 			return [directoryManager storageURL];
-		}]
+		}]]
 		flattenMap:^(NSURL *storageURL) {
 			NSURL *updateDirectoryTemplate = [storageURL URLByAppendingPathComponent:[SQRLUpdaterUniqueTemporaryDirectoryPrefix stringByAppendingString:@"XXXXXXX"]];
 			char *updateDirectoryCString = strdup(updateDirectoryTemplate.path.fileSystemRepresentation);
@@ -666,25 +674,68 @@ BOOL isVersionStandard(NSString* version) {
 			return [directoryManager storageURL];
 		}]
 		flattenMap:^(NSURL *storageURL) {
-			NSFileManager *manager = [[NSFileManager alloc] init];
-			NSDirectoryEnumerator *enumerator = [manager enumeratorAtURL:storageURL includingPropertiesForKeys:nil options:NSDirectoryEnumerationSkipsSubdirectoryDescendants errorHandler:^(NSURL *URL, NSError *error) {
-				NSLog(@"Error enumerating item %@ within directory %@: %@", URL, storageURL, error);
-				return YES;
-			}];
-
-			return [[enumerator.rac_sequence.signal
-				filter:^(NSURL *enumeratedURL) {
-					NSString *name = enumeratedURL.lastPathComponent;
-					return [name hasPrefix:SQRLUpdaterUniqueTemporaryDirectoryPrefix];
-				}]
-				doNext:^(NSURL *directoryURL) {
-					NSError *error = nil;
-					if (![manager removeItemAtURL:directoryURL error:&error]) {
-						NSLog(@"Error removing old update directory at %@: %@", directoryURL, error.sqrl_verboseDescription);
-					}
-				}];
+			return [self removeUpdateDirectoriesInStorageURL:storageURL excludingURL:nil];
 		}]
 		setNameWithFormat:@"%@ -prunedUpdateDirectories", self];
+}
+
+/// Lazily removes orphaned temporary directories upon subscription, always
+/// preserving the directory currently referenced by ShipItState.plist so that
+/// quitAndInstall remains safe to call mid-check.
+///
+/// Safe to call in any state. Sends each removed directory then completes on
+/// an unspecified thread. Errors reading the staged request are swallowed
+/// (treated as "nothing staged").
+- (RACSignal *)pruneOrphanedUpdateDirectories {
+	return [[[[[SQRLShipItRequest
+		readUsingURL:self.shipItStateURL]
+		map:^(SQRLShipItRequest *request) {
+			// The request holds the URL to the staged .app bundle; its parent
+			// is the update.XXXXXXX directory we must preserve.
+			return [request.updateBundleURL URLByDeletingLastPathComponent];
+		}]
+		catch:^(NSError *error) {
+			// No staged request (or unreadable) — nothing to preserve.
+			return [RACSignal return:nil];
+		}]
+		flattenMap:^(NSURL *stagedDirectoryURL) {
+			SQRLDirectoryManager *directoryManager = [[SQRLDirectoryManager alloc] initWithApplicationIdentifier:SQRLShipItLauncher.shipItJobLabel];
+			return [[directoryManager storageURL]
+				flattenMap:^(NSURL *storageURL) {
+					return [self removeUpdateDirectoriesInStorageURL:storageURL excludingURL:stagedDirectoryURL];
+				}];
+		}]
+		setNameWithFormat:@"%@ -pruneOrphanedUpdateDirectories", self];
+}
+
+/// Shared enumerate-and-delete logic for update temp directories.
+///
+/// storageURL  - The Squirrel storage root to enumerate. Must not be nil.
+/// excludedURL - Directory to skip (compared by standardized path). May be nil.
+- (RACSignal *)removeUpdateDirectoriesInStorageURL:(NSURL *)storageURL excludingURL:(NSURL *)excludedURL {
+	NSParameterAssert(storageURL != nil);
+
+	NSFileManager *manager = [[NSFileManager alloc] init];
+	NSDirectoryEnumerator *enumerator = [manager enumeratorAtURL:storageURL includingPropertiesForKeys:nil options:NSDirectoryEnumerationSkipsSubdirectoryDescendants errorHandler:^(NSURL *URL, NSError *error) {
+		NSLog(@"Error enumerating item %@ within directory %@: %@", URL, storageURL, error);
+		return YES;
+	}];
+
+	NSString *excludedPath = excludedURL.URLByStandardizingPath.path;
+
+	return [[enumerator.rac_sequence.signal
+		filter:^(NSURL *enumeratedURL) {
+			NSString *name = enumeratedURL.lastPathComponent;
+			if (![name hasPrefix:SQRLUpdaterUniqueTemporaryDirectoryPrefix]) return NO;
+			if (excludedPath != nil && [enumeratedURL.URLByStandardizingPath.path isEqualToString:excludedPath]) return NO;
+			return YES;
+		}]
+		doNext:^(NSURL *directoryURL) {
+			NSError *error = nil;
+			if (![manager removeItemAtURL:directoryURL error:&error]) {
+				NSLog(@"Error removing old update directory at %@: %@", directoryURL, error.sqrl_verboseDescription);
+			}
+		}];
 }
 
 

--- a/Squirrel/ShipIt-main.m
+++ b/Squirrel/ShipIt-main.m
@@ -158,8 +158,14 @@ static void installRequest(RACSignal *readRequestSignal, NSString *applicationId
 			return action;
 		}]
 		subscribeError:^(NSError *error) {
-			NSLog(@"Installation error: %@", error);
-			exit(EXIT_FAILURE);
+			if ([[error domain] isEqual:SQRLInstallerErrorDomain] && [error code] == SQRLInstallerErrorAppStillRunning) {
+				NSLog(@"Installation cancelled: %@", error);
+				clearInstallationAttempts(applicationIdentifier);
+				exit(EXIT_SUCCESS);
+			} else {
+				NSLog(@"Installation error: %@", error);
+				exit(EXIT_FAILURE);
+			}
 		} completed:^{
 			exit(EXIT_SUCCESS);
 		}];

--- a/Squirrel/ShipIt-main.m
+++ b/Squirrel/ShipIt-main.m
@@ -13,12 +13,31 @@
 #import <ReactiveObjC/RACSignal+Operations.h>
 #import <ReactiveObjC/RACScheduler.h>
 
+#include <spawn.h>
+#include <sys/wait.h>
+#include <mach/mach.h>
+#include <servers/bootstrap.h>
+
 #import "NSError+SQRLVerbosityExtensions.h"
 #import "RACSignal+SQRLTransactionExtensions.h"
 #import "SQRLInstaller.h"
 #import "SQRLInstaller+Private.h"
 #import "SQRLTerminationListener.h"
 #import "SQRLShipItRequest.h"
+
+extern char **environ;
+
+int responsibility_spawnattrs_setdisclaim(posix_spawnattr_t attrs, int disclaim)
+__attribute__((availability(macos,introduced=10.14),weak_import));
+
+#define CHECK_ERR(expr) \
+	{ \
+		int err = (expr); \
+    if (err) { \
+        fprintf(stderr, "%s: %s", #expr, strerror(err)); \
+        exit(err); \
+    } \
+	}
 
 // The maximum number of times ShipIt should run the same installation state, in
 // an attempt to update.
@@ -44,6 +63,28 @@ static BOOL setInstallationAttempts(NSString *applicationIdentifier, NSUInteger 
 static BOOL clearInstallationAttempts(NSString *applicationIdentifier) {
 	CFPreferencesSetValue((__bridge CFStringRef)SQRLShipItInstallationAttemptsKey, NULL, (__bridge CFStringRef)applicationIdentifier, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
 	return CFPreferencesSynchronize((__bridge CFStringRef)applicationIdentifier, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
+}
+
+// Drain the Mach service port registered via MachServices in the launchd
+// job dictionary before exit(0) so launchd sees no outstanding demand and
+// does not immediately respawn the job. bootstrap_check_in transfers the
+// receive right into this task, but that alone is not sufficient: launchd
+// tracks demand independently of the port's lifetime, so the queued
+// trigger message must be explicitly dequeued. On failure exits the
+// message is intentionally left queued so the KeepAlive respawn is
+// demand-backed while the launchd domain is in on-demand-only mode.
+static void drainMachServicePort(const char *serviceName) {
+	mach_port_t port = MACH_PORT_NULL;
+	if (bootstrap_check_in(bootstrap_port, serviceName, &port) != KERN_SUCCESS) return;
+
+	struct {
+		mach_msg_header_t header;
+		uint8_t body[4096];
+	} msg;
+	while (mach_msg(&msg.header, MACH_RCV_MSG | MACH_RCV_TIMEOUT,
+	                0, sizeof(msg), port, 0, MACH_PORT_NULL) == KERN_SUCCESS) {
+		mach_msg_destroy(&msg.header);
+	}
 }
 
 // Waits for all instances of the target application (as described in the
@@ -136,19 +177,47 @@ static void installRequest(RACSignal *readRequestSignal, NSString *applicationId
 							NSString *exe = NSProcessInfo.processInfo.arguments[0];
 							NSLog(@"Launching new ShipIt at %@ with instructions to launch %@", exe, bundleURL);
 
-							NSTask *task = [[NSTask alloc] init];
-							[task setLaunchPath: exe];
-							[task setArguments: @[launchSignal, bundleURL.path]];
-							[task launch];
-							[task waitUntilExit];
+							posix_spawnattr_t attr;
+							CHECK_ERR(posix_spawnattr_init(&attr));
+
+							// Disclaim TCC responsibilities
+							if (responsibility_spawnattrs_setdisclaim)
+									CHECK_ERR(responsibility_spawnattrs_setdisclaim(&attr, 1));
+
+							pid_t pid = 0;
+
+							const char* launchPath = [exe fileSystemRepresentation];
+							const char* signal = [launchSignal fileSystemRepresentation];
+							const char* path = [bundleURL.path fileSystemRepresentation];
+							const char* args[] = { launchPath, signal, path, 0 };
+							int status = posix_spawn(&pid, [exe UTF8String], NULL, &attr, (char *const*)args, environ);
+							if (status == 0) {
+								NSLog(@"New ShipIt pid: %i", pid);
+								do {
+									if (waitpid(pid, &status, 0) != -1) {
+										NSLog(@"ShipIt status %d", WEXITSTATUS(status));
+									} else {
+										perror("waitpid");
+										exit(1);
+									}
+								} while (!WIFEXITED(status) && !WIFSIGNALED(status));
+							} else {
+								NSLog(@"posix_spawn: %s", strerror(status));
+							}
+
+							posix_spawnattr_destroy(&attr);
 
 							NSLog(@"New ShipIt exited");
 						} else {
 							NSLog(@"Attempting to launch app on lower than 11.0");
+// TODO: https://github.com/electron/electron/issues/43168
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 							if (![NSWorkspace.sharedWorkspace launchApplicationAtURL:bundleURL options:NSWorkspaceLaunchDefault configuration:@{} error:&error]) {
 								NSLog(@"Could not launch application at %@: %@", bundleURL, error);
 								return;
 							}
+#pragma clang diagnostic pop
 
 							NSLog(@"Application launched at %@", bundleURL);
 						}
@@ -161,12 +230,14 @@ static void installRequest(RACSignal *readRequestSignal, NSString *applicationId
 			if ([[error domain] isEqual:SQRLInstallerErrorDomain] && [error code] == SQRLInstallerErrorAppStillRunning) {
 				NSLog(@"Installation cancelled: %@", error);
 				clearInstallationAttempts(applicationIdentifier);
+				drainMachServicePort(applicationIdentifier.UTF8String);
 				exit(EXIT_SUCCESS);
 			} else {
 				NSLog(@"Installation error: %@", error);
 				exit(EXIT_FAILURE);
 			}
 		} completed:^{
+			drainMachServicePort(applicationIdentifier.UTF8String);
 			exit(EXIT_SUCCESS);
 		}];
 }
@@ -178,7 +249,13 @@ int main(int argc, const char * argv[]) {
 		});
 
 		if (argc < 3) {
-			NSLog(@"Missing launchd job label or state path for ShipIt");
+			NSLog(@"Missing launchd job label or state path for ShipIt (%d)", argc);
+			if (argc >= 1) {
+				NSLog(@"Arg 1: {%s}", argv[0]);
+			}
+			if (argc >= 2) {
+				NSLog(@"Arg 2: {%s}", argv[1]);
+			}
 			return EXIT_FAILURE;
 		}
 
@@ -188,12 +265,16 @@ int main(int argc, const char * argv[]) {
 
 		if (strcmp(jobLabel, [launchSignal UTF8String]) == 0) {
 			NSLog(@"Detected this as a launch request");
+// TODO: https://github.com/electron/electron/issues/43168
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 			NSError *error;
 			if (![NSWorkspace.sharedWorkspace launchApplicationAtURL:shipItStateURL options:NSWorkspaceLaunchDefault configuration:@{} error:&error]) {
 				NSLog(@"Could not launch application at %@: %@", shipItStateURL, error);
 			} else {
 				NSLog(@"Successfully launched application at %@", shipItStateURL);
 			}
+#pragma clang diagnostic pop
 			exit(EXIT_SUCCESS);
 		} else {
 			NSLog(@"Detected this as an install request");

--- a/SquirrelTests/SQRLInstallerSpec.m
+++ b/SquirrelTests/SQRLInstallerSpec.m
@@ -19,6 +19,8 @@
 
 #import "QuickSpec+SQRLFixtures.h"
 
+#import <sys/xattr.h>
+
 QuickSpecBegin(SQRLInstallerSpec)
 
 mode_t (^modeOfURL)(NSURL *) = ^ mode_t (NSURL *fileURL) {
@@ -53,6 +55,37 @@ it(@"should install an update in process", ^{
 	[self installWithRequest:request remote:NO];
 
 	expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
+});
+
+describe(@"with SquirrelMacEnableDirectContentsWrite enabled", ^{
+	beforeEach(^{
+		// SQRLInstaller adds the running application's identifier (and that
+		// identifier minus a trailing .ShipIt) as search suites, but
+		// `[[NSUserDefaults alloc] init]` already includes the host app's
+		// domain — so writing via standardUserDefaults is sufficient when
+		// running the installer in-process.
+		[NSUserDefaults.standardUserDefaults setBool:YES forKey:@"SquirrelMacEnableDirectContentsWrite"];
+
+		[self addCleanupBlock:^{
+			[NSUserDefaults.standardUserDefaults removeObjectForKey:@"SquirrelMacEnableDirectContentsWrite"];
+		}];
+	});
+
+	it(@"should install an update by replacing Contents and leave the .app directory itself untouched", ^{
+		const char *xattrName = "com.github.Squirrel.spec-id";
+		NSString *marker = NSProcessInfo.processInfo.globallyUniqueString;
+		expect(@(setxattr(self.testApplicationURL.fileSystemRepresentation, xattrName, marker.UTF8String, strlen(marker.UTF8String), 0, 0))).to(equal(@0));
+
+		SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:updateURL targetBundleURL:self.testApplicationURL bundleIdentifier:nil launchAfterInstallation:NO useUpdateBundleName:NO];
+		[self installWithRequest:request remote:NO];
+
+		expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
+
+		NSMutableData *buf = [NSMutableData dataWithLength:256];
+		ssize_t len = getxattr(self.testApplicationURL.fileSystemRepresentation, xattrName, buf.mutableBytes, buf.length, 0, 0);
+		expect(@(len)).to(beGreaterThan(@0));
+		expect([[NSString alloc] initWithBytes:buf.bytes length:(NSUInteger)len encoding:NSUTF8StringEncoding]).to(equal(marker));
+	});
 });
 
 it(@"should install an update and relaunch", ^{

--- a/SquirrelTests/SQRLInstallerSpec.m
+++ b/SquirrelTests/SQRLInstallerSpec.m
@@ -49,6 +49,21 @@ it(@"should install an update using ShipIt", ^{
 	expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
 });
 
+it(@"should round-trip the owned bundle through CFPreferences", ^{
+	SQRLInstaller *installer = [[SQRLInstaller alloc] initWithApplicationIdentifier:self.shipItDirectoryManager.applicationIdentifier];
+	SQRLInstallerOwnedBundle *original = [[SQRLInstallerOwnedBundle alloc] initWithOriginalURL:self.testApplicationURL temporaryURL:updateURL codeSignature:self.testApplicationSignature];
+
+	[installer setValue:original forKey:@"ownedBundle"];
+
+	SQRLInstallerOwnedBundle *restored = [installer valueForKey:@"ownedBundle"];
+	expect(restored).notTo(beNil());
+	expect(restored.originalURL).to(equal(original.originalURL));
+	expect(restored.temporaryURL).to(equal(original.temporaryURL));
+
+	[installer setValue:nil forKey:@"ownedBundle"];
+	expect([installer valueForKey:@"ownedBundle"]).to(beNil());
+});
+
 it(@"should install an update in process", ^{
 	SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:updateURL targetBundleURL:self.testApplicationURL bundleIdentifier:nil launchAfterInstallation:NO useUpdateBundleName:NO];
 

--- a/SquirrelTests/SQRLInstallerSpec.m
+++ b/SquirrelTests/SQRLInstallerSpec.m
@@ -88,6 +88,38 @@ describe(@"with SquirrelMacEnableDirectContentsWrite enabled", ^{
 	});
 });
 
+it(@"should refuse to install when the target bundle path traverses a symlink", ^{
+	NSURL *symlinkURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:@"symlinked.app"];
+	expect(@([NSFileManager.defaultManager createSymbolicLinkAtURL:symlinkURL withDestinationURL:self.testApplicationURL error:NULL])).to(beTruthy());
+
+	SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:updateURL targetBundleURL:symlinkURL bundleIdentifier:nil launchAfterInstallation:NO useUpdateBundleName:NO];
+
+	SQRLInstaller *installer = [[SQRLInstaller alloc] initWithApplicationIdentifier:self.shipItDirectoryManager.applicationIdentifier];
+	NSError *error = nil;
+	BOOL installed = [[installer.installUpdateCommand execute:request] asynchronouslyWaitUntilCompleted:&error];
+
+	expect(@(installed)).to(beFalsy());
+	expect(error.domain).to(equal(SQRLInstallerErrorDomain));
+	expect(@(error.code)).to(equal(@(SQRLInstallerErrorInvalidState)));
+});
+
+it(@"should abort the install if the target application is still running", ^{
+	NSRunningApplication *app = [self launchTestApplicationWithEnvironment:nil];
+	expect(@(app.isTerminated)).to(beFalsy());
+
+	SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:updateURL targetBundleURL:self.testApplicationURL bundleIdentifier:@"com.github.Squirrel.TestApplication" launchAfterInstallation:NO useUpdateBundleName:NO];
+
+	SQRLInstaller *installer = [[SQRLInstaller alloc] initWithApplicationIdentifier:self.shipItDirectoryManager.applicationIdentifier];
+	NSError *error = nil;
+	BOOL installed = [[installer.installUpdateCommand execute:request] asynchronouslyWaitUntilCompleted:&error];
+
+	expect(@(installed)).to(beFalsy());
+	expect(error.domain).to(equal(SQRLInstallerErrorDomain));
+	expect(@(error.code)).to(equal(@(SQRLInstallerErrorAppStillRunning)));
+
+	expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationOriginalShortVersionString));
+});
+
 it(@"should install an update and relaunch", ^{
 	NSString *bundleIdentifier = @"com.github.Squirrel.TestApplication";
 	NSArray *apps = [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleIdentifier];

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -631,4 +631,18 @@ describe(@"state", ^{
 	});
 });
 
+describe(@"+isVersionAllowedForUpdate:from:", ^{
+	it(@"should compare version numbers correctly", ^{
+		expect(@([SQRLUpdater isVersionAllowedForUpdate:@"2.0.0" from:@"1.0.0"])).to(beTruthy());
+		expect(@([SQRLUpdater isVersionAllowedForUpdate:@"1.0.10" from:@"1.0.1"])).to(beTruthy());
+		expect(@([SQRLUpdater isVersionAllowedForUpdate:@"1.0.1" from:@"1.0.10"])).to(beFalsy());
+		expect(@([SQRLUpdater isVersionAllowedForUpdate:@"1.32.0" from:@"1.31.1"])).to(beTruthy());
+		expect(@([SQRLUpdater isVersionAllowedForUpdate:@"0.32.0" from:@"1.31.1"])).to(beFalsy());
+	});
+
+	it(@"should allow updating to the same version", ^{
+		expect(@([SQRLUpdater isVersionAllowedForUpdate:@"1.2.3" from:@"1.2.3"])).to(beTruthy());
+	});
+});
+
 QuickSpecEnd

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -21,6 +21,10 @@
 #import "TestAppConstants.h"
 #import <objc/objc-class.h>
 
+@interface SQRLUpdater (SQRLTestingHooks)
+- (RACSignal *)removeUpdateDirectoriesInStorageURL:(NSURL *)storageURL excludingURL:(NSURL *)excludedURL;
+@end
+
 //! force Updater to believe we are not on readonly, to continue downloading the release
 bool isRunningOnReadOnlyVolumeImp(id self, SEL _cmd)
 {
@@ -459,17 +463,12 @@ describe(@"updating", ^{
 				}];
 		});
 
-		// Disabled: pruneUpdateDirectories intentionally skips while the
-		// updater is in SQRLUpdaterStateAwaitingRelaunch (see 7dffc4b /
-		// Squirrel#174), so the staged update directory is expected to
-		// remain on disk until the next cold update check.
-		xit(@"should remove downloaded archives after updating", ^{
+		it(@"should keep the update directory count bounded across repeated checks", ^{
 			SKIP_IF_RUNNING_ON_TRAVIS
 
 			NSError *error = nil;
 			SQRLTestUpdate *update = [SQRLTestUpdate modelWithDictionary:@{
 				@"updateURL": zipUpdate(updateURL),
-				@"final": @YES
 			} error:&error];
 
 			expect(update).notTo(beNil());
@@ -477,12 +476,45 @@ describe(@"updating", ^{
 
 			writeUpdate(update);
 
-			NSRunningApplication *app = launchWithEnvironment(@{ @"SQRLUpdateRequestCount": @"2" });
+			NSRunningApplication *app = launchWithEnvironment(@{ @"SQRLUpdateRequestCount": @"3" });
 			expect([updateDirectoryURLs toArray]).toEventuallyNot(equal(@[]));
 			expect(@(app.terminated)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
-			expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
 
-			expect([updateDirectoryURLs toArray]).withTimeout(SQRLLongTimeout).toEventually(equal(@[]));
+			// pruneOrphanedUpdateDirectories runs before each download and
+			// preserves only the directory referenced by the current
+			// ShipItState, so after N checks at most 2 directories remain
+			// (the most recently staged + the one created during the final
+			// check).
+			expect(@([[updateDirectoryURLs toArray] count])).to(beLessThanOrEqualTo(@2));
+		});
+
+		it(@"should remove orphaned update directories while preserving the excluded one", ^{
+			NSURL *storageURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:@"prune-storage"];
+			expect(@([NSFileManager.defaultManager createDirectoryAtURL:storageURL withIntermediateDirectories:YES attributes:nil error:NULL])).to(beTruthy());
+
+			NSURL *staged = nil;
+			for (int i = 0; i < 4; i++) {
+				NSURL *dir = [storageURL URLByAppendingPathComponent:[NSString stringWithFormat:@"update.ORPHAN%d", i]];
+				expect(@([NSFileManager.defaultManager createDirectoryAtURL:dir withIntermediateDirectories:YES attributes:nil error:NULL])).to(beTruthy());
+				if (i == 2) staged = dir;
+			}
+			// Non-prefixed directory must be left alone.
+			NSURL *unrelated = [storageURL URLByAppendingPathComponent:@"ShipItState.plist"];
+			[NSData.data writeToURL:unrelated atomically:YES];
+
+			SQRLUpdater *updater = [SQRLUpdater alloc];
+			BOOL ok = [[updater removeUpdateDirectoriesInStorageURL:storageURL excludingURL:staged] asynchronouslyWaitUntilCompleted:NULL];
+			expect(@(ok)).to(beTruthy());
+
+			NSArray *remaining = [NSFileManager.defaultManager contentsOfDirectoryAtURL:storageURL includingPropertiesForKeys:nil options:0 error:NULL];
+			NSPredicate *isUpdateDir = [NSPredicate predicateWithBlock:^BOOL(NSURL *url, NSDictionary *bindings) {
+				return [url.lastPathComponent hasPrefix:@"update."];
+			}];
+			NSArray *remainingUpdateDirs = [remaining filteredArrayUsingPredicate:isUpdateDir];
+
+			expect(@(remainingUpdateDirs.count)).to(equal(@1));
+			expect([remainingUpdateDirs.firstObject lastPathComponent]).to(equal(staged.lastPathComponent));
+			expect(@([NSFileManager.defaultManager fileExistsAtPath:unrelated.path])).to(beTruthy());
 		});
 	});
 });


### PR DESCRIPTION
Upstreams the remaining `electron/patches/squirrel.mac/` patches into this repo so Electron can eventually drop them. Six commits, **8 files, +537/−51**, **63 → 74 tests**.

| Commit | Upstreams | Tests added |
|---|---|---|
| `feat: SquirrelMacEnableDirectContentsWrite` | `feat_add_new_squirrel_mac_bundle_installation_method_behind_flag` | parent-dir-untouched e2e |
| `fix: abort install if app running; resolve target path once` | `fix_abort_installation_attempt_at_the_final_mile_if_the_app_is` + `fix_resolve_target_bundle_path_once_at_start_of_install` | symlink-target rejected, abort-if-running |
| `feat: ElectronSquirrelPreventDowngrades` | `feat_add_ability_to_prevent_version_downgrades` | `+isVersionAllowedForUpdate:from:` units |
| `refactor: harden ShipIt launch` | `refactor_use_posix_spawn_instead_of_nstask…` + `fix_trigger_shipit_mach_service_after_smjobsubmit…` + `chore_turn_off_launchapplicationaturl_deprecation…` | (existing remote-ShipIt spec exercises new path) |
| `refactor: non-deprecated NSKeyedArchiver` | `refactor_use_non-deprecated_nskeyedarchiver_apis` | `SQRLInstallerOwnedBundle` round-trip |
| `fix: prune orphaned staged updates` | `fix_clean_up_orphaned_staged_updates_before_downloading_new_update` | unit prune + e2e bounded-count; replaces `xit` |

Fixes #124. Fixes #196. Fixes #264.

> [!NOTE]
> Two adaptations should be backported to Electron's patches:
> - `SQRLUpdater.m`: `BOOL launchPrivileged = !targetWritable` in the original `direct-contents-write` patch shadowed the outer var — it was a dead store
> - `SQRLInstaller.m`: `runningApplicationsWithBundleIdentifier:` throws on `nil`; guarded it

Replaces the stacked #303 / #304 / #305 / #306 / #307 / #309. #302 (strict codesign validation) stays separate — it touches only `SQRLCodeSignature.m`.
