### PR TITLE
fix: invert isVersionStandard superset check so numeric versions pass

### DIFF
--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -48,7 +48,7 @@ BOOL isVersionStandard(NSString* version) {
 	NSArray* versionParts = [version componentsSeparatedByString:@"."];
 	BOOL versionBad = [versionParts count] != 3;
 	for (NSString* part in versionParts) {
-		versionBad = versionBad || [alphaNums isSupersetOfSet:[NSCharacterSet characterSetWithCharactersInString:part]];
+		versionBad = versionBad || part.length == 0 || ![alphaNums isSupersetOfSet:[NSCharacterSet characterSetWithCharactersInString:part]];
 	}
 
 	return !versionBad;

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -27,6 +27,8 @@
 @property (nonatomic, strong, readonly) RACSignal *shipItLauncher;
 @end
 
+extern BOOL isVersionStandard(NSString* version);
+
 //! controllable stub for +[SQRLShipItLauncher launchPrivileged:]
 static int launchPrivilegedCallCount = 0;
 static RACSignal *(^launchPrivilegedStub)(BOOL) = nil;
@@ -727,6 +729,35 @@ describe(@"shipItLauncher", ^{
 		expect(@(success)).to(beTruthy());
 		expect(error).to(beNil());
 		expect(@(launchPrivilegedCallCount)).to(equal(@2));
+	});
+});
+
+describe(@"isVersionStandard", ^{
+	it(@"should accept simple Major.Minor.Patch version strings", ^{
+		expect(@(isVersionStandard(@"1.2.3"))).to(beTruthy());
+		expect(@(isVersionStandard(@"0.0.0"))).to(beTruthy());
+		expect(@(isVersionStandard(@"10.20.30"))).to(beTruthy());
+		expect(@(isVersionStandard(@"100.0.1"))).to(beTruthy());
+	});
+
+	it(@"should reject version strings without exactly three parts", ^{
+		expect(@(isVersionStandard(@"1.2"))).to(beFalsy());
+		expect(@(isVersionStandard(@"1.2.3.4"))).to(beFalsy());
+		expect(@(isVersionStandard(@"1"))).to(beFalsy());
+		expect(@(isVersionStandard(@""))).to(beFalsy());
+	});
+
+	it(@"should reject version strings with non-numeric parts", ^{
+		expect(@(isVersionStandard(@"1.2.3-beta"))).to(beFalsy());
+		expect(@(isVersionStandard(@"a.b.c"))).to(beFalsy());
+		expect(@(isVersionStandard(@"1.2.x"))).to(beFalsy());
+		expect(@(isVersionStandard(@"v1.2.3"))).to(beFalsy());
+	});
+
+	it(@"should reject version strings with empty parts", ^{
+		expect(@(isVersionStandard(@"1..3"))).to(beFalsy());
+		expect(@(isVersionStandard(@".."))).to(beFalsy());
+		expect(@(isVersionStandard(@".2.3"))).to(beFalsy());
 	});
 });
 


### PR DESCRIPTION
`isVersionStandard` was OR'ing the result of `[decimalDigits isSupersetOfSet:partChars]` into `versionBad` without negation — so an all-digit part marked the version as **bad**. `isVersionStandard(@"1.2.3")` returned `NO`; `isVersionStandard(@"a.b.c")` returned `YES`.

Effect: any app with `ElectronSquirrelPreventDowngrades` enabled fails every update at the `'is not a valid version string'` check for normal versions, never reaching the actual downgrade comparison.

This went unnoticed because the existing tests only cover `+isVersionAllowedForUpdate:from:` (the comparison), not the format gate in front of it.

Also rejects empty parts (`"1..3"`) — the empty set is trivially a subset of digits, so it would otherwise slip through after the negation fix.

Adds direct unit coverage for `isVersionStandard`.