### PR TITLE
fix: don't cache shipItLauncher errors across update checks

### DIFF
--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -335,9 +335,16 @@ BOOL isVersionStandard(NSString* version) {
 			deliverOn:RACScheduler.mainThreadScheduler];
 	}];
 
-	_shipItLauncher = [[[RACSignal
+	__block BOOL shipItSubmitted = NO;
+	_shipItLauncher = [[RACSignal
 		defer:^{
 			@strongify(self);
+
+			// replayLazily would cache a terminal error (e.g. the user
+			// cancelling the auth prompt, or a transient SMJobSubmit failure)
+			// and replay it to every future check. Memoize success only so
+			// errors retry on the next subscription.
+			if (shipItSubmitted) return [RACSignal empty];
 
 			NSURL *targetURL = NSRunningApplication.currentApplication.bundleURL.URLByResolvingSymlinksInPath;
 
@@ -348,9 +355,11 @@ BOOL isVersionStandard(NSString* version) {
 				// If SquirrelMacEnableDirectContentsWrite is enabled we don't care if the parent directory is writeable or not
 				launchPrivileged = !targetWritable;
 			}
-			return [SQRLShipItLauncher launchPrivileged:launchPrivileged];
+			return [[SQRLShipItLauncher launchPrivileged:launchPrivileged]
+				doCompleted:^{
+					shipItSubmitted = YES;
+				}];
 		}]
-		replayLazily]
 		setNameWithFormat:@"shipItLauncher"];
 	
 	return self;

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -12,6 +12,7 @@
 #import <Squirrel/Squirrel.h>
 
 #import "SQRLDirectoryManager.h"
+#import "SQRLShipItLauncher.h"
 #import "SQRLUpdater.h"
 #import "SQRLZipArchiver.h"
 
@@ -23,7 +24,17 @@
 
 @interface SQRLUpdater (SQRLTestingHooks)
 - (RACSignal *)removeUpdateDirectoriesInStorageURL:(NSURL *)storageURL excludingURL:(NSURL *)excludedURL;
+@property (nonatomic, strong, readonly) RACSignal *shipItLauncher;
 @end
+
+//! controllable stub for +[SQRLShipItLauncher launchPrivileged:]
+static int launchPrivilegedCallCount = 0;
+static RACSignal *(^launchPrivilegedStub)(BOOL) = nil;
+RACSignal * launchPrivilegedImp(id self, SEL _cmd, BOOL privileged)
+{
+	launchPrivilegedCallCount++;
+	return launchPrivilegedStub != nil ? launchPrivilegedStub(privileged) : [RACSignal empty];
+}
 
 //! force Updater to believe we are not on readonly, to continue downloading the release
 bool isRunningOnReadOnlyVolumeImp(id self, SEL _cmd)
@@ -660,6 +671,62 @@ describe(@"state", ^{
 		expect(states).withTimeout(SQRLLongTimeout).toEventually(equal(expectedStates));
 
 		expect(@(testApplication.terminated)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
+	});
+});
+
+describe(@"shipItLauncher", ^{
+	__block IMP originalLaunchPrivileged;
+	__block Method launchPrivilegedMethod;
+	__block SQRLUpdater *updater;
+
+	beforeEach(^{
+		launchPrivilegedCallCount = 0;
+		launchPrivilegedStub = nil;
+
+		launchPrivilegedMethod = class_getClassMethod(SQRLShipItLauncher.class, @selector(launchPrivileged:));
+		originalLaunchPrivileged = method_setImplementation(launchPrivilegedMethod, (IMP)launchPrivilegedImp);
+
+		NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://fake/"]];
+		updater = [[SQRLUpdater alloc] initWithUpdateRequest:request];
+	});
+
+	afterEach(^{
+		method_setImplementation(launchPrivilegedMethod, originalLaunchPrivileged);
+		launchPrivilegedStub = nil;
+	});
+
+	it(@"should not re-submit the launchd job after a successful launch", ^{
+		launchPrivilegedStub = ^(BOOL privileged) { return [RACSignal empty]; };
+
+		NSError *error = nil;
+		BOOL success = [updater.shipItLauncher waitUntilCompleted:&error];
+		expect(@(success)).to(beTruthy());
+		expect(error).to(beNil());
+		expect(@(launchPrivilegedCallCount)).to(equal(@1));
+
+		success = [updater.shipItLauncher waitUntilCompleted:&error];
+		expect(@(success)).to(beTruthy());
+		expect(@(launchPrivilegedCallCount)).to(equal(@1));
+	});
+
+	it(@"should retry the launch on the next subscription after an error", ^{
+		NSError *cancelled = [NSError errorWithDomain:NSOSStatusErrorDomain code:-60006 userInfo:nil];
+		launchPrivilegedStub = ^(BOOL privileged) { return [RACSignal error:cancelled]; };
+
+		NSError *error = nil;
+		BOOL success = [updater.shipItLauncher waitUntilCompleted:&error];
+		expect(@(success)).to(beFalsy());
+		expect(error).to(equal(cancelled));
+		expect(@(launchPrivilegedCallCount)).to(equal(@1));
+
+		// User re-authorizes / transient SMJobSubmit failure clears.
+		launchPrivilegedStub = ^(BOOL privileged) { return [RACSignal empty]; };
+
+		error = nil;
+		success = [updater.shipItLauncher waitUntilCompleted:&error];
+		expect(@(success)).to(beTruthy());
+		expect(error).to(beNil());
+		expect(@(launchPrivilegedCallCount)).to(equal(@2));
 	});
 });
 


### PR DESCRIPTION
Fixes #315.

`_shipItLauncher` wrapped `+[SQRLShipItLauncher launchPrivileged:]` in `replayLazily`, which buffers terminal events. If the first subscription errored — the user cancelling the auth prompt (`errAuthorizationCanceled` / `-60006`) or a transient `SMJobSubmit` failure — every subsequent check replayed that error without re-invoking `launchPrivileged:`. Each interval would re-download, re-verify, write `ShipItState.plist`, hit the cached error, and delete the staged update, until process restart.

Replaces `replayLazily` with a `doCompleted:` flag: success is still memoized (the launchd job dict is update-agnostic; ShipIt re-reads `ShipItState.plist` after `waitForTermination`, so submit-once-per-process was already the contract), but errors fall through and retry on the next subscription.

The sole consumer is `then:` so the dropped value-replay is a no-op (`+launchPrivileged:` returns `[RACSignal empty]` on success anyway).

Two new tests:
- `should not re-submit the launchd job after a successful launch` — locks in the existing invariant
- `should retry the launch on the next subscription after an error` — fails on `main`, passes here