### PR TITLE
fix: forward requestForDownload in -initWithUpdateRequest:requestForDownload:

### DIFF
--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -172,9 +172,7 @@ BOOL isVersionStandard(NSString* version) {
 }
 
 - (id)initWithUpdateRequest:(NSURLRequest *)updateRequest requestForDownload:(SQRLRequestForDownload)requestForDownload {
-	return [self initWithUpdateRequest:updateRequest requestForDownload:^(NSURL *downloadURL) {
-		return [NSURLRequest requestWithURL:downloadURL];
-	} forVersion:nil useMode:RELEASESERVER];
+	return [self initWithUpdateRequest:updateRequest requestForDownload:requestForDownload forVersion:nil useMode:RELEASESERVER];
 }
 
 - (id)initWithUpdateRequest:(NSURLRequest *)updateRequest requestForDownload:(SQRLRequestForDownload)requestForDownload

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -761,6 +761,22 @@ describe(@"isVersionStandard", ^{
 	});
 });
 
+describe(@"-initWithUpdateRequest:requestForDownload:", ^{
+	it(@"should use the provided requestForDownload block", ^{
+		NSURLRequest *updateRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://fake/update-check"]];
+		SQRLUpdater *updater = [[SQRLUpdater alloc] initWithUpdateRequest:updateRequest requestForDownload:^(NSURL *downloadURL) {
+			NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:downloadURL];
+			[request setValue:@"Bearer test-token" forHTTPHeaderField:@"Authorization"];
+			return request;
+		}];
+
+		NSURL *downloadURL = [NSURL URLWithString:@"http://fake/app.zip"];
+		NSURLRequest *downloadRequest = updater.requestForDownload(downloadURL);
+		expect(downloadRequest.URL).to(equal(downloadURL));
+		expect([downloadRequest valueForHTTPHeaderField:@"Authorization"]).to(equal(@"Bearer test-token"));
+	});
+});
+
 describe(@"+isVersionAllowedForUpdate:from:", ^{
 	it(@"should compare version numbers correctly", ^{
 		expect(@([SQRLUpdater isVersionAllowedForUpdate:@"2.0.0" from:@"1.0.0"])).to(beTruthy());


### PR DESCRIPTION
The two-arg convenience initializer accepted a `requestForDownload` block and discarded it, forwarding a fresh default block to the designated initializer instead. `SQRLUpdater.h:152-157` documents this overload as the way to attach `Authorization` headers to the zip download, and `h:106-107` promises the property's default is "the argument that was originally passed to `-initWithUpdateRequest:requestForDownload:`" — neither was true.

Regressed in c80f0066. The 4-arg designated initializer and the writable `requestForDownload` property both work, which is likely why this was never reported.

Adds a test that fails on `main`.