### PR TITLE
Cleanup: dead code removal + assorted low-risk correctness fixes

### DIFF
--- a/Squirrel/RACSignal+SQRLTransactionExtensions.m
+++ b/Squirrel/RACSignal+SQRLTransactionExtensions.m
@@ -52,7 +52,7 @@ static RACDisposable *SQRLCreateTransaction(NSString *name, NSString *descriptio
 
 	[NSProcessInfo.processInfo disableSuddenTermination];
 
-	IOPMAssertionID powerAssertion;
+	IOPMAssertionID powerAssertion = kIOPMNullAssertionID;
 	IOReturn result = IOPMAssertionCreateWithDescription(kIOPMAssertionTypePreventSystemSleep, (__bridge CFStringRef)name, (__bridge CFStringRef)description, NULL, NULL, SQRLTransactionPowerAssertionTimeout, kIOPMAssertionTimeoutActionLog, &powerAssertion);
 	if (result != kIOReturnSuccess) {
 		NSLog(@"Could not install power assertion: %li", (long)result);
@@ -79,9 +79,11 @@ static RACDisposable *SQRLCreateTransaction(NSString *name, NSString *descriptio
 		}
 		[SQRLTransactionLock() unlock];
 
-		IOReturn result = IOPMAssertionRelease(powerAssertion);
-		if (result != kIOReturnSuccess) {
-			NSLog(@"Could not release power assertion: %li", (long)result);
+		if (powerAssertion != kIOPMNullAssertionID) {
+			IOReturn result = IOPMAssertionRelease(powerAssertion);
+			if (result != kIOReturnSuccess) {
+				NSLog(@"Could not release power assertion: %li", (long)result);
+			}
 		}
 
 		[NSProcessInfo.processInfo enableSuddenTermination];

--- a/Squirrel/SQRLInstaller.m
+++ b/Squirrel/SQRLInstaller.m
@@ -477,6 +477,10 @@ NSString * const SQRLInstallerOwnedBundleKey = @"SQRLInstallerOwnedBundle";
 			NSError *error;
 			if ([NSFileManager.defaultManager removeItemAtURL:bundleURL error:&error]) {
 				return [RACSignal empty];
+			} else if ([error.domain isEqualToString:NSCocoaErrorDomain] && error.code == NSFileNoSuchFileError) {
+				// The bundle was already moved into place by installItemToURL:;
+				// proceed so the parent mkdtemp directory still gets removed.
+				return [RACSignal empty];
 			} else {
 				return [RACSignal error:error];
 			}

--- a/Squirrel/SQRLInstaller.m
+++ b/Squirrel/SQRLInstaller.m
@@ -503,7 +503,7 @@ NSString * const SQRLInstallerOwnedBundleKey = @"SQRLInstallerOwnedBundle";
 				userInfo[NSLocalizedFailureReasonErrorKey] = [NSString stringWithFormat:NSLocalizedString(@"Couldn't remove temp dir \"%@\"", @""), temporaryDirectoryURL.path];
 				userInfo[NSURLErrorKey] = temporaryDirectoryURL;
 
-				return [RACSignal error:[NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:userInfo]];
+				return [RACSignal error:[NSError errorWithDomain:NSPOSIXErrorDomain code:code userInfo:userInfo]];
 			}
 		}]
 		setNameWithFormat:@"%@ -deleteOwnedBundleAtURL: %@", self, bundleURL];

--- a/Squirrel/SQRLUpdate.m
+++ b/Squirrel/SQRLUpdate.m
@@ -93,17 +93,7 @@ NSString * const SQRLUpdateJSONPublicationDateKey = @"pub_date";
 			if (date != nil) return date;
 		}
 
-		// If neither match, try removing the ':' in the time zone
-		static NSRegularExpression *timeZoneSuffix = nil;
-		static dispatch_once_t timeZoneSuffixPredicate = 0;
-		dispatch_once(&timeZoneSuffixPredicate, ^ {
-			timeZoneSuffix = [NSRegularExpression regularExpressionWithPattern:@"([-+])([0-9]{2}):([0-9]{2})$" options:0 error:NULL];
-		});
-
-		dateString = [timeZoneSuffix stringByReplacingMatchesInString:dateString options:0 range:NSMakeRange(0, dateString.length) withTemplate:@"$1$2$3"];
-
-		formatter.dateFormat = @"yyyy'-'MM'-'DD'T'HH':'mm':'ssZZZ"; // RFC 822 Time Zone no ':', 10.7 support
-		return [formatter dateFromString:dateString];
+		return nil;
 	} reverseBlock:^ NSString * (NSDate *date, BOOL *success, NSError **error) {
 		if (![date isKindOfClass:NSDate.class]) return nil;
 

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -233,71 +233,71 @@ BOOL isVersionStandard(NSString* version) {
 				return [NSURLConnection rac_sendAsynchronousRequest:request];
 			}]
 			reduceEach:^(NSURLResponse *response, NSData *bodyData) {
-				if ([response isKindOfClass:NSHTTPURLResponse.class]) {
+				BOOL readOnlyVolume = [self isRunningOnReadOnlyVolume];
+				if (readOnlyVolume) {
+					NSDictionary *errorInfo = @{
+					NSLocalizedDescriptionKey: NSLocalizedString(@"Cannot update while running on a read-only volume", nil),
+					NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"The application is on a read-only volume. Please move the application and try again. If you're on macOS Sierra or later, you'll need to move the application out of the Downloads directory. See https://github.com/Squirrel/Squirrel.Mac/issues/182 for more information.", nil),
+					};
+					NSError *error = [NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorReadOnlyVolume userInfo:errorInfo];
+					return [RACSignal error:error];
+				}
+
+				if ([response isKindOfClass:NSHTTPURLResponse.class] && mode == RELEASESERVER) {
 					NSHTTPURLResponse *httpResponse = (id)response;
 
-					BOOL readOnlyVolume = [self isRunningOnReadOnlyVolume];
-					if (readOnlyVolume) {
+					if (!(httpResponse.statusCode >= 200 && httpResponse.statusCode <= 299)) {
 						NSDictionary *errorInfo = @{
-						NSLocalizedDescriptionKey: NSLocalizedString(@"Cannot update while running on a read-only volume", nil),
-						NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"The application is on a read-only volume. Please move the application and try again. If you're on macOS Sierra or later, you'll need to move the application out of the Downloads directory. See https://github.com/Squirrel/Squirrel.Mac/issues/182 for more information.", nil),
+								NSLocalizedDescriptionKey: NSLocalizedString(@"Update check failed", nil),
+								NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"The server sent an invalid response. Try again later.", nil),
+								SQRLUpdaterServerDataErrorKey: bodyData,
 						};
-						NSError *error = [NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorReadOnlyVolume userInfo:errorInfo];
+						NSError *error = [NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorInvalidServerResponse userInfo:errorInfo];
 						return [RACSignal error:error];
 					}
 
-					if (mode == RELEASESERVER) {
-						if (!(httpResponse.statusCode >= 200 && httpResponse.statusCode <= 299)) {
-							NSDictionary *errorInfo = @{
-									NSLocalizedDescriptionKey: NSLocalizedString(@"Update check failed", nil),
-									NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"The server sent an invalid response. Try again later.", nil),
-									SQRLUpdaterServerDataErrorKey: bodyData,
-							};
-							NSError *error = [NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorInvalidServerResponse userInfo:errorInfo];
-							return [RACSignal error:error];
-						}
+					if (httpResponse.statusCode == 204 /* No Content */) {
+						return [RACSignal empty];
+					}
+				}
 
-						if (httpResponse.statusCode == 204 /* No Content */) {
+				if (mode == JSONFILE) {
+					NSError *error = nil;
+					NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:bodyData options:0 error:&error];
+
+					if (dict == nil) {
+						NSMutableDictionary *userInfo = [error.userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
+						userInfo[NSLocalizedDescriptionKey] = NSLocalizedString(@"Update check failed", nil);
+						userInfo[NSLocalizedRecoverySuggestionErrorKey] = NSLocalizedString(@"The server sent an invalid response. Try again later.", nil);
+						userInfo[SQRLUpdaterServerDataErrorKey] = bodyData;
+						if (error != nil) userInfo[NSUnderlyingErrorKey] = error;
+
+						return [RACSignal error:[NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorInvalidServerBody userInfo:userInfo]];
+					}
+
+					NSString *currentRelease = dict[@"currentRelease"];
+					if(currentRelease) {
+						//! if CDN points to the currently running version as the latest version, bail out
+						if([currentRelease isEqualToString:version]) {
+							NSLog(@"The running client is already the latest version.");
 							return [RACSignal empty];
 						}
-					} else if (mode == JSONFILE) {
-						NSError *error = nil;
-						NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:bodyData options:0 error:&error];
 
-						if (dict == nil) {
-							NSMutableDictionary *userInfo = [error.userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
-							userInfo[NSLocalizedDescriptionKey] = NSLocalizedString(@"Update check failed", nil);
-							userInfo[NSLocalizedRecoverySuggestionErrorKey] = NSLocalizedString(@"The server sent an invalid response. Try again later.", nil);
-							userInfo[SQRLUpdaterServerDataErrorKey] = bodyData;
-							if (error != nil) userInfo[NSUnderlyingErrorKey] = error;
-
-							return [RACSignal error:[NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorInvalidServerBody userInfo:userInfo]];
+						if ([version compare:currentRelease options:NSNumericSearch] == NSOrderedDescending) {
+							// currentRelease is lower than version.
+							// Might be a new version for testing that is not deployed yet
+							// no roll back
+							NSLog(@"The running client is newer than the latest deployed release. Not downgrading.");
+							return [RACSignal empty];
 						}
 
-						NSString *currentRelease = dict[@"currentRelease"];
-						if(currentRelease) {
-							//! if CDN points to the currently running version as the latest version, bail out
-							if([currentRelease isEqualToString:version]) {
-								NSLog(@"The running client is already the latest version.");
-								return [RACSignal empty];
-							}
-
-							if ([version compare:currentRelease options:NSNumericSearch] == NSOrderedDescending) {
-								// currentRelease is lower than version.
-								// Might be a new version for testing that is not deployed yet
-								// no roll back
-								NSLog(@"The running client is newer than the latest deployed release. Not downgrading.");
-								return [RACSignal empty];
-							}
-
-							//! @todo find latest
-							NSArray *releases = dict[@"releases"];
-							for(NSDictionary* release in releases) {
-								if([currentRelease isEqualToString:release[@"version"]]) {
-									bodyData = [NSJSONSerialization dataWithJSONObject:release[@"updateTo"]
-																				options:0 error:&error];
-									break;
-								}
+						//! @todo find latest
+						NSArray *releases = dict[@"releases"];
+						for(NSDictionary* release in releases) {
+							if([currentRelease isEqualToString:release[@"version"]]) {
+								bodyData = [NSJSONSerialization dataWithJSONObject:release[@"updateTo"]
+																			options:0 error:&error];
+								break;
 							}
 						}
 					}

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -657,8 +657,8 @@ BOOL isVersionStandard(NSString* version) {
 }
 
 - (RACSignal *)performHousekeeping {
-	return [[RACSignal
-		merge:@[ [self pruneUpdateDirectories], [self truncateLogs] ]]
+	return [[self
+		pruneUpdateDirectories]
 		catch:^(NSError *error) {
 			NSLog(@"Error doing housekeeping: %@", error);
 			return [RACSignal empty];
@@ -744,39 +744,6 @@ BOOL isVersionStandard(NSString* version) {
 			if (![manager removeItemAtURL:directoryURL error:&error]) {
 				NSLog(@"Error removing old update directory at %@: %@", directoryURL, error.sqrl_verboseDescription);
 			}
-		}];
-}
-
-
-// Like truncation, but backwards.
-- (RACSignal *)backwardTruncateFile:(NSURL *)fileURL {
-	return [RACSignal defer:^{
-		static const NSInteger MAX_LENGTH = 1024 * 1024 * 8;
-
-		NSError *error;
-		NSFileHandle *handle = [NSFileHandle fileHandleForWritingToURL:fileURL error:&error];
-		if (handle == nil) return [RACSignal error:error];
-
-		unsigned long long fileLength = [handle seekToEndOfFile];
-		if (fileLength <= MAX_LENGTH) return [RACSignal empty];
-
-		[handle seekToFileOffset:fileLength - MAX_LENGTH];
-		NSData *mostRecentData = [handle readDataToEndOfFile];
-		[handle truncateFileAtOffset:0];
-		[handle writeData:mostRecentData];
-
-		return [RACSignal empty];
-	}];
-}
-
-- (RACSignal *)truncateLogs {
-	return [[RACSignal
-		defer:^{
-			SQRLDirectoryManager *directoryManager = [[SQRLDirectoryManager alloc] initWithApplicationIdentifier:SQRLShipItLauncher.shipItJobLabel];
-			return [RACSignal zip:@[ [directoryManager shipItStdoutURL], [directoryManager shipItStderrURL] ]];
-		}]
-		reduceEach:^(NSURL *stdoutURL, NSURL *stderrURL) {
-			return [RACSignal merge:@[ [self backwardTruncateFile:stdoutURL], [self backwardTruncateFile:stderrURL] ]];
 		}];
 }
 

--- a/SquirrelTests/SQRLInstallerSpec.m
+++ b/SquirrelTests/SQRLInstallerSpec.m
@@ -21,6 +21,10 @@
 
 #import <sys/xattr.h>
 
+@interface SQRLInstaller (SQRLTestingHooks)
+- (RACSignal *)deleteOwnedBundleAtURL:(NSURL *)bundleURL;
+@end
+
 QuickSpecBegin(SQRLInstallerSpec)
 
 mode_t (^modeOfURL)(NSURL *) = ^ mode_t (NSURL *fileURL) {
@@ -303,6 +307,56 @@ describe(@"signal handling", ^{
 		}
 
 		verifyUpdate();
+	});
+});
+
+describe(@"-deleteOwnedBundleAtURL:", ^{
+	__block SQRLInstaller *installer;
+	__block NSURL *parentURL;
+	__block NSURL *bundleURL;
+
+	beforeEach(^{
+		installer = [[SQRLInstaller alloc] initWithApplicationIdentifier:@"com.github.SquirrelTests"];
+		parentURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:NSProcessInfo.processInfo.globallyUniqueString isDirectory:YES];
+		bundleURL = [parentURL URLByAppendingPathComponent:@"Test.app" isDirectory:YES];
+		expect(@([NSFileManager.defaultManager createDirectoryAtURL:parentURL withIntermediateDirectories:YES attributes:nil error:NULL])).to(beTruthy());
+	});
+
+	it(@"should remove the bundle and its parent directory", ^{
+		expect(@([NSFileManager.defaultManager createDirectoryAtURL:bundleURL withIntermediateDirectories:YES attributes:nil error:NULL])).to(beTruthy());
+
+		NSError *error = nil;
+		BOOL success = [[installer deleteOwnedBundleAtURL:bundleURL] asynchronouslyWaitUntilCompleted:&error];
+
+		expect(@(success)).to(beTruthy());
+		expect(error).to(beNil());
+		expect(@([NSFileManager.defaultManager fileExistsAtPath:bundleURL.path])).to(beFalsy());
+		expect(@([NSFileManager.defaultManager fileExistsAtPath:parentURL.path])).to(beFalsy());
+	});
+
+	it(@"should remove the parent directory when the bundle is already gone", ^{
+		expect(@([NSFileManager.defaultManager fileExistsAtPath:bundleURL.path])).to(beFalsy());
+
+		NSError *error = nil;
+		BOOL success = [[installer deleteOwnedBundleAtURL:bundleURL] asynchronouslyWaitUntilCompleted:&error];
+
+		expect(@(success)).to(beTruthy());
+		expect(error).to(beNil());
+		expect(@([NSFileManager.defaultManager fileExistsAtPath:parentURL.path])).to(beFalsy());
+	});
+
+	it(@"should report the rmdir errno when the parent directory is not empty", ^{
+		expect(@([NSFileManager.defaultManager createDirectoryAtURL:bundleURL withIntermediateDirectories:YES attributes:nil error:NULL])).to(beTruthy());
+		NSURL *siblingURL = [parentURL URLByAppendingPathComponent:@"stray-file"];
+		expect(@([[NSData data] writeToURL:siblingURL atomically:YES])).to(beTruthy());
+
+		NSError *error = nil;
+		BOOL success = [[installer deleteOwnedBundleAtURL:bundleURL] asynchronouslyWaitUntilCompleted:&error];
+
+		expect(@(success)).to(beFalsy());
+		expect(error.domain).to(equal(NSPOSIXErrorDomain));
+		expect(@(error.code)).to(equal(@(ENOTEMPTY)));
+		expect(@([NSFileManager.defaultManager fileExistsAtPath:siblingURL.path])).to(beTruthy());
 	});
 });
 

--- a/SquirrelTests/SQRLUpdateSpec.m
+++ b/SquirrelTests/SQRLUpdateSpec.m
@@ -53,4 +53,14 @@ it(@"should parse ISO 8601 dates", ^{
 	expect(update.releaseDate).to(equal([NSDate dateWithTimeIntervalSince1970:1379506627]));
 });
 
+it(@"should parse ISO 8601 dates with a colon-free time zone offset", ^{
+	SQRLUpdate *update = [MTLJSONAdapter modelOfClass:SQRLUpdate.class fromJSONDictionary:@{ @"url": @"http://example.com/update", @"pub_date": @"2013-09-18T13:17:07-0700" } error:NULL];
+	expect(update.releaseDate).to(equal([NSDate dateWithTimeIntervalSince1970:1379535427]));
+});
+
+it(@"should parse ISO 8601 dates with a Z time zone designator", ^{
+	SQRLUpdate *update = [MTLJSONAdapter modelOfClass:SQRLUpdate.class fromJSONDictionary:@{ @"url": @"http://example.com/update", @"pub_date": @"2013-09-18T12:17:07Z" } error:NULL];
+	expect(update.releaseDate).to(equal([NSDate dateWithTimeIntervalSince1970:1379506627]));
+});
+
 QuickSpecEnd

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -340,6 +340,33 @@ describe(@"checkForUpdatesCommand", ^{
 			expect((BOOL)updateFromJSONDataIsCalled).to(beFalse());
 		});
 
+		it(@"should pick the matching release's updateTo when reading the manifest from a file:// URL", ^{
+			NSDictionary *updateTo = @{
+				@"version": @"2.0.0",
+				@"url": @"http://fake/app-2.0.0.zip",
+				@"name": @"v2",
+			};
+			NSDictionary *manifest = @{
+				@"currentRelease": @"2.0.0",
+				@"releases": @[
+					@{ @"version": @"2.0.0", @"updateTo": updateTo },
+				],
+			};
+			NSURL *manifestURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:@"releases.json"];
+			NSData *manifestData = [NSJSONSerialization dataWithJSONObject:manifest options:0 error:NULL];
+			expect(@([manifestData writeToURL:manifestURL atomically:YES])).to(beTruthy());
+
+			NSURLRequest *request = [NSURLRequest requestWithURL:manifestURL];
+			SQRLUpdater *updater = [[SQRLUpdater alloc] initWithUpdateRequest:request forVersion:@"1.0.0"];
+			NSError *error = nil;
+			BOOL result = [[updater.checkForUpdatesCommand execute:nil] asynchronouslyWaitUntilCompleted:&error];
+
+			expect(@(result)).to(beTruthy());
+			expect(error).to(beNil());
+			expect((BOOL)updateFromJSONDataIsCalled).to(beTrue());
+			expect(updateFromJSONDataLastBody).to(equal(updateTo));
+		});
+
 		it(@"should error when the JSON file is invalid", ^{
 			OHHTTPStubs *stubs = [OHHTTPStubs shouldStubRequestsPassingTest:^(NSURLRequest *request) {
 				return [request.URL.absoluteString isEqualToString:@"http://fake/releases.json"];


### PR DESCRIPTION
Batch of small, independent cleanups found during a whole-repo audit. Each is an atomic commit; happy to split any out if preferred.

| Commit | Tests |
|---|---|
| **chore: remove dead `truncateLogs` / `backwardTruncateFile`** — `reduceEach:` was never followed by `flatten`, so the inner signal was emitted as a value and never subscribed; the rotation has been a no-op since it landed in 2016. The helper also opened the handle write-only then called `readDataToEndOfFile`, so wiring it up would have thrown rather than rotated. | n/a (dead code removal) |
| **fix: handle `file://` feed URLs in JSONFILE mode** — the JSONFILE manifest transform sat inside `if ([response isKindOfClass:NSHTTPURLResponse.class])`, so a local-file feed (which the header docs explicitly mention for testing) skipped the transform and failed with `SQRLUpdaterErrorInvalidJSON`. Only the HTTP-status checks stay gated now. | +1 |
| **fix: don't release uninitialized `IOPMAssertionID` on create failure** — initialize to `kIOPMNullAssertionID` and guard the release. The out-param is documented as written on success only. | none — `IOPMAssertionCreateWithDescription` is called directly inside a static C function with no injection point; making it fail under test would require refactoring the function signature. The fix is mechanical (init + guard). |
| **fix: use saved `errno` snapshot when building rmdir `NSError`** — `code:errno` → `code:code`, matching the parallel `rename()` error path that already does this. | covered by the `should report the rmdir errno…` case below |
| **fix: don't leak mkdtemp parent dir when bundle was already moved** — `deleteOwnedBundleAtURL:` now treats `ENOENT` from `removeItemAtURL:` as success so the chained `rmdir` runs. Previously every successful install left one empty 0700 dir under `NSTemporaryDirectory()` plus a spurious "No such file" log line. | +3 (`-deleteOwnedBundleAtURL:` happy path, already-gone path, non-empty parent reports `ENOTEMPTY`) |
| **chore: remove pre-10.13 `releaseDate` fallback parser** — the fallback used `DD` (day-of-year) instead of `dd`, but the primary `ZZZZZ` format already accepts every shape it covered on the current deployment target. | +2 (confirms `+0000` / `-07:00` parse via the primary path) |