### PR TITLE
test: wait for ShipIt to exit before asserting on install result

### DIFF
--- a/SquirrelTests/QuickSpec+SQRLFixtures.h
+++ b/SquirrelTests/QuickSpec+SQRLFixtures.h
@@ -87,7 +87,20 @@ extern const NSTimeInterval SQRLLongTimeout;
 - (NSURL *)createTestApplicationUpdate;
 
 // Runs the installer in process or submits ShipIt's launchd job to start it up.
+//
+// When `remote` is YES, this blocks until the ShipIt launchd job has exited so
+// callers can assert on the install result synchronously. Use
+// -submitShipItRequest: directly for tests that need to interact with ShipIt
+// while it's running.
 - (void)installWithRequest:(SQRLShipItRequest *)request remote:(BOOL)remote;
+
+// Writes the request to ShipIt's state file and submits the launchd job
+// without waiting for ShipIt to run.
+- (void)submitShipItRequest:(SQRLShipItRequest *)request;
+
+// Polls launchd until the given job has run and exited (LastExitStatus is set
+// and PID is absent).
+- (void)waitForShipItJobToExitWithLabel:(NSString *)jobLabel;
 
 // Creates a disk image, then mounts it.
 //

--- a/SquirrelTests/QuickSpec+SQRLFixtures.m
+++ b/SquirrelTests/QuickSpec+SQRLFixtures.m
@@ -283,28 +283,52 @@ QuickConfigurationEnd
 	return manager;
 }
 
+- (void)submitShipItRequest:(SQRLShipItRequest *)request {
+	expect(@([[request writeUsingURL:self.shipItDirectoryManager.shipItStateURL] waitUntilCompleted:NULL])).to(beTruthy());
+
+	__block NSError *error = nil;
+	expect(@([[SQRLShipItLauncher launchPrivileged:NO] waitUntilCompleted:&error])).to(beTruthy());
+	expect(error).to(beNil());
+
+	[self addCleanupBlock:^{
+		// Remove ShipIt's launchd job so it doesn't relaunch itself.
+		#pragma clang diagnostic push
+		#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+		SMJobRemove(kSMDomainUserLaunchd, (__bridge CFStringRef)SQRLShipItLauncher.shipItJobLabel, NULL, true, NULL);
+		#pragma clang diagnostic pop
+
+		NSError *lookupError;
+		NSURL *stateURL = [[self.shipItDirectoryManager shipItStateURL] firstOrDefault:nil success:NULL error:&lookupError];
+		expect(stateURL).notTo(beNil());
+		expect(lookupError).to(beNil());
+
+		[NSFileManager.defaultManager removeItemAtURL:stateURL error:NULL];
+	}];
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+static NSNumber *SQRLShipItLastExitStatus(NSString *jobLabel) {
+	NSDictionary *job = CFBridgingRelease(SMJobCopyDictionary(kSMDomainUserLaunchd, (__bridge CFStringRef)jobLabel));
+	if (job == nil || job[@"PID"] != nil) return nil;
+	return job[@"LastExitStatus"];
+}
+#pragma clang diagnostic pop
+
+- (void)waitForShipItJobToExitWithLabel:(NSString *)jobLabel {
+	// launchPrivileged: only submits the launchd job and triggers an on-demand
+	// spawn — it does not wait for ShipIt to actually run. Block until launchd
+	// reports the job has exited so callers can assert on the install result
+	// synchronously instead of racing Nimble's default 1s poll timeout.
+	// LastExitStatus only appears once the process has run and exited, which
+	// avoids the brief no-PID window before launchd spawns it.
+	expect(SQRLShipItLastExitStatus(jobLabel)).withTimeout(SQRLLongTimeout).toEventuallyNot(beNil());
+}
+
 - (void)installWithRequest:(SQRLShipItRequest *)request remote:(BOOL)remote {
 	if (remote) {
-		expect(@([[request writeUsingURL:self.shipItDirectoryManager.shipItStateURL] waitUntilCompleted:NULL])).to(beTruthy());
-
-		__block NSError *error = nil;
-		expect(@([[SQRLShipItLauncher launchPrivileged:NO] waitUntilCompleted:&error])).to(beTruthy());
-		expect(error).to(beNil());
-
-		[self addCleanupBlock:^{
-			// Remove ShipIt's launchd job so it doesn't relaunch itself.
-			#pragma clang diagnostic push
-			#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-			SMJobRemove(kSMDomainUserLaunchd, (__bridge CFStringRef)SQRLShipItLauncher.shipItJobLabel, NULL, true, NULL);
-			#pragma clang diagnostic pop
-
-			NSError *lookupError;
-			NSURL *stateURL = [[self.shipItDirectoryManager shipItStateURL] firstOrDefault:nil success:NULL error:&lookupError];
-			expect(stateURL).notTo(beNil());
-			expect(lookupError).to(beNil());
-
-			[NSFileManager.defaultManager removeItemAtURL:stateURL error:NULL];
-		}];
+		[self submitShipItRequest:request];
+		[self waitForShipItJobToExitWithLabel:SQRLShipItLauncher.shipItJobLabel];
 	} else {
 		SQRLInstaller *installer = [[SQRLInstaller alloc] initWithApplicationIdentifier:self.shipItDirectoryManager.applicationIdentifier];
 		expect(installer).notTo(beNil());

--- a/SquirrelTests/SQRLInstallerSpec.m
+++ b/SquirrelTests/SQRLInstallerSpec.m
@@ -46,7 +46,7 @@ it(@"should install an update using ShipIt", ^{
 
 	[self installWithRequest:request remote:YES];
 
-	expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
+	expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationUpdatedShortVersionString));
 });
 
 it(@"should round-trip the owned bundle through CFPreferences", ^{
@@ -69,7 +69,7 @@ it(@"should install an update in process", ^{
 
 	[self installWithRequest:request remote:NO];
 
-	expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
+	expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationUpdatedShortVersionString));
 });
 
 describe(@"with SquirrelMacEnableDirectContentsWrite enabled", ^{
@@ -94,7 +94,7 @@ describe(@"with SquirrelMacEnableDirectContentsWrite enabled", ^{
 		SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:updateURL targetBundleURL:self.testApplicationURL bundleIdentifier:nil launchAfterInstallation:NO useUpdateBundleName:NO];
 		[self installWithRequest:request remote:NO];
 
-		expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
+		expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationUpdatedShortVersionString));
 
 		NSMutableData *buf = [NSMutableData dataWithLength:256];
 		ssize_t len = getxattr(self.testApplicationURL.fileSystemRepresentation, xattrName, buf.mutableBytes, buf.length, 0, 0);
@@ -144,8 +144,8 @@ it(@"should install an update and relaunch", ^{
 
 	[self installWithRequest:request remote:YES];
 
-	expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
-	expect(@([NSRunningApplication runningApplicationsWithBundleIdentifier:bundleIdentifier].count)).toEventually(equal(@1));
+	expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationUpdatedShortVersionString));
+	expect(@([NSRunningApplication runningApplicationsWithBundleIdentifier:bundleIdentifier].count)).withTimeout(SQRLLongTimeout).toEventually(equal(@1));
 });
 
 it(@"should install an update from another volume", ^{
@@ -156,7 +156,7 @@ it(@"should install an update from another volume", ^{
 
 	[self installWithRequest:request remote:YES];
 
-	expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
+	expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationUpdatedShortVersionString));
 });
 
 it(@"should install an update to another volume", ^{
@@ -168,7 +168,7 @@ it(@"should install an update to another volume", ^{
 	[self installWithRequest:request remote:YES];
 
 	NSURL *plistURL = [targetURL URLByAppendingPathComponent:@"Contents/Info.plist"];
-	expect([NSDictionary dictionaryWithContentsOfURL:plistURL][SQRLBundleShortVersionStringKey]).withTimeout(SQRLLongTimeout).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
+	expect([NSDictionary dictionaryWithContentsOfURL:plistURL][SQRLBundleShortVersionStringKey]).to(equal(SQRLTestApplicationUpdatedShortVersionString));
 });
 
 describe(@"with backup restoration", ^{
@@ -202,7 +202,7 @@ describe(@"with backup restoration", ^{
 		[self installWithRequest:request remote:YES];
 
 		__block NSError *error;
-		expect(@([[self.testApplicationSignature verifyBundleAtURL:targetURL] waitUntilCompleted:&error])).toEventually(beTruthy());
+		expect(@([[self.testApplicationSignature verifyBundleAtURL:targetURL] waitUntilCompleted:&error])).to(beTruthy());
 		expect(error).to(beNil());
 
 		expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationOriginalShortVersionString));
@@ -212,7 +212,7 @@ describe(@"with backup restoration", ^{
 		SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:updateURL targetBundleURL:targetURL bundleIdentifier:nil launchAfterInstallation:YES useUpdateBundleName:NO];
 		[self installWithRequest:request remote:YES];
 
-		expect(@([NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.github.Squirrel.TestApplication"].count)).toEventually(equal(@1));
+		expect(@([NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.github.Squirrel.TestApplication"].count)).withTimeout(SQRLLongTimeout).toEventually(equal(@1));
 
 		__block NSError *error;
 		expect(@([[self.testApplicationSignature verifyBundleAtURL:targetURL] waitUntilCompleted:&error])).to(beTruthy());
@@ -233,7 +233,7 @@ it(@"should disallow writing the updated application except by the owner", ^{
 
 	[self installWithRequest:request remote:YES];
 
-	expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
+	expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationUpdatedShortVersionString));
 
 	expect(@(modeOfURL(self.testApplicationURL))).to(equal(@0755));
 	expect(@(modeOfURL([self.testApplicationURL URLByAppendingPathComponent:@"Contents/MacOS/TestApplication"]))).to(equal(@0755));
@@ -260,7 +260,8 @@ describe(@"signal handling", ^{
 
 		SQRLShipItRequest *request = [[SQRLShipItRequest alloc] initWithUpdateBundleURL:updateURL targetBundleURL:self.testApplicationURL bundleIdentifier:nil launchAfterInstallation:NO useUpdateBundleName:NO];
 
-		[self installWithRequest:request remote:YES];
+		// Submit without waiting so the test can signal ShipIt mid-install.
+		[self submitShipItRequest:request];
 
 		// Apply a random delay before sending the termination signal, to
 		// fuzz out race conditions.

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -383,7 +383,8 @@ describe(@"updating", ^{
 
 		NSRunningApplication *app = launchWithEnvironment(nil);
 		expect(@(app.terminated)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
-		expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
+		[self waitForShipItJobToExitWithLabel:@"com.github.Squirrel.TestApplication.ShipIt"];
+		expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationUpdatedShortVersionString));
 	});
 
 	it(@"should not install a corrupt update", ^{
@@ -434,7 +435,8 @@ describe(@"updating", ^{
 		writeUpdate(update);
 
 		expect(@(app.terminated)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
-		expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
+		[self waitForShipItJobToExitWithLabel:@"com.github.Squirrel.TestApplication.ShipIt"];
+		expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationUpdatedShortVersionString));
 	});
 
 	it(@"should use the application's bundled version of Squirrel and update in-place after a significant delay", ^{
@@ -451,7 +453,8 @@ describe(@"updating", ^{
 		NSRunningApplication *app = launchWithEnvironment(@{ @"SQRLUpdateDelay": [NSString stringWithFormat:@"%f", delay] });
 
 		expect(@(app.terminated)).withTimeout(delay + SQRLLongTimeout).toEventually(beTruthy());
-		expect(self.testApplicationBundleVersion).toEventually(equal(SQRLTestApplicationUpdatedShortVersionString));
+		[self waitForShipItJobToExitWithLabel:@"com.github.Squirrel.TestApplication.ShipIt"];
+		expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationUpdatedShortVersionString));
 	});
 
 	describe(@"cleaning up", ^{


### PR DESCRIPTION
`-installWithRequest:remote:YES` previously returned immediately after `SMJobSubmit`, leaving callers to poll `testApplicationBundleVersion` with Nimble's default **1-second** `toEventually` timeout. On slow CI hosts (the `macos-15-intel` runner in particular) that races launchd spawn → codesign verify → bundle rename and intermittently loses, surfacing as `expected to eventually equal <2.1>, got <1.0>`.

This isn't a retry — the timeout was objectively wrong for an out-of-process install. Two of the eleven call sites had already worked around it locally with `withTimeout(SQRLLongTimeout)`; this makes the wait deterministic at the source instead.

**Changes:**
- New `-submitShipItRequest:` (fire-and-forget — the signal-handling tests need to interrupt ShipIt mid-install) and `-waitForShipItJobToExitWithLabel:` (polls `SMJobCopyDictionary` for `LastExitStatus`, which only appears after the process has actually run and exited — avoids the brief no-PID window before launchd spawns it).
- `-installWithRequest:remote:YES` now calls both, so its callers assert synchronously with `.to(equal:)`.
- The `SQRLUpdaterSpec` end-to-end tests that launch `TestApplication` and let it submit its own ShipIt job get the same wait with the TestApplication-derived label.
- The remaining `toEventually` calls (relaunch detection via `runningApplicationsWithBundleIdentifier:`) are genuinely async and now use `SQRLLongTimeout` explicitly.

44/44 across `SQRLInstallerSpec` + `SQRLUpdaterSpec` locally.