### PR TITLE
test: post state transitions with deliverImmediately and assert after termination

### DIFF
--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -663,15 +663,17 @@ describe(@"state", ^{
 		}];
 
 		NSRunningApplication *testApplication = launchWithEnvironment(nil);
+		expect(@(testApplication.terminated)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
 
+		// The app has run to completion; every state notification has been
+		// posted (with deliverImmediately:YES). Allow notifyd a moment to
+		// deliver any in-flight notifications before asserting the sequence.
 		NSArray *expectedStates = @[
 			@(SQRLUpdaterStateIdle),
 			@(SQRLUpdaterStateCheckingForUpdate),
 			@(SQRLUpdaterStateIdle),
 		];
-		expect(states).toEventually(equal(expectedStates));
-
-		expect(@(testApplication.terminated)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
+		expect(states).withTimeout(SQRLLongTimeout).toEventually(equal(expectedStates));
 	});
 
 	it(@"should transition through idle, checking, downloading and awaiting relaunch, when there is an update", ^{
@@ -693,7 +695,11 @@ describe(@"state", ^{
 		writeUpdate(update);
 
 		NSRunningApplication *testApplication = launchWithEnvironment(nil);
+		expect(@(testApplication.terminated)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
 
+		// The app has run to completion; every state notification has been
+		// posted (with deliverImmediately:YES). Allow notifyd a moment to
+		// deliver any in-flight notifications before asserting the sequence.
 		NSArray *expectedStates = @[
 			@(SQRLUpdaterStateIdle),
 			@(SQRLUpdaterStateCheckingForUpdate),
@@ -701,8 +707,6 @@ describe(@"state", ^{
 			@(SQRLUpdaterStateAwaitingRelaunch),
 		];
 		expect(states).withTimeout(SQRLLongTimeout).toEventually(equal(expectedStates));
-
-		expect(@(testApplication.terminated)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
 	});
 });
 

--- a/TestApplication/TestAppDelegate.m
+++ b/TestApplication/TestAppDelegate.m
@@ -67,7 +67,7 @@
 	[RACObserve(self.updater, state) subscribeNext:^(NSNumber *state) {
 		NSLog(@"State transition: %@", state);
 
-		[NSDistributedNotificationCenter.defaultCenter postNotificationName:SQRLTestAppUpdaterStateTransitionNotificationName object:nil userInfo:@{ SQRLTestAppUpdaterStateKey: state }];
+		[NSDistributedNotificationCenter.defaultCenter postNotificationName:SQRLTestAppUpdaterStateTransitionNotificationName object:nil userInfo:@{ SQRLTestAppUpdaterStateKey: state } deliverImmediately:YES];
 	}];
 
 	__block NSUInteger updateCheckCount = 1;


### PR DESCRIPTION
The `state` describe block observes `SQRLUpdaterState` changes via `NSDistributedNotificationCenter` from the launched `TestApplication`. The posts used the default-coalescing form (`postNotificationName:object:userInfo:`), so the final `AwaitingRelaunch` notification — posted right before the app calls `relaunchToInstallUpdate` and exits — can sit in the per-process queue and be discarded at termination. Seen on `macOS 14 arm64` as:

```
expected to eventually equal <(0, 1, 2, 3)>, got <(0, 1, 2)>
```

**Root-cause fix:** post with `deliverImmediately:YES` so each transition is handed to `notifyd` synchronously.

**Ordering fix:** wait for `testApplication.terminated` first, *then* assert on `states`. Once the app has exited, every notification has been posted; the assertion only needs to allow for in-flight delivery from `notifyd`, not race the entire download → verify → stage pipeline against a wall clock.

Also adds the missing `withTimeout(SQRLLongTimeout)` to the no-update variant, which was still on Nimble's 1s default.