### PR TITLE
fix: bound zip archiver standard error collection

### DIFF
--- a/Squirrel/SQRLZipArchiver.m
+++ b/Squirrel/SQRLZipArchiver.m
@@ -14,6 +14,11 @@ NSString * const SQRLZipArchiverErrorDomain = @"SQRLZipArchiverErrorDomain";
 NSString * const SQRLZipArchiverExitCodeErrorKey = @"SQRLZipArchiverExitCodeErrorKey";
 const NSInteger SQRLZipArchiverShellTaskFailed = 1;
 
+// `ditto` writes diagnostics for input it cannot process. Keep the retained
+// untrusted output bounded so a failed archive operation cannot exhaust memory.
+static const NSUInteger kSQRLZipArchiverMaximumStandardErrorDataLength =
+	1024 * 1024;
+
 @interface SQRLZipArchiver () {
 	RACSubject *_taskTerminated;
 }
@@ -30,8 +35,8 @@ const NSInteger SQRLZipArchiverShellTaskFailed = 1;
 // A pipe used for reading error logging from `dittoTask`.
 @property (nonatomic, strong, readonly) NSPipe *standardErrorPipe;
 
-// Sends an NSData representing the error logging from `dittoTask` once the task
-// has terminated.
+// Sends up to 1 MiB of error logging from `dittoTask` once the task has
+// terminated.
 @property (nonatomic, strong, readonly) RACSignal *standardErrorData;
 
 // Launches the receiver's `dittoTask` with the given command line arguments.
@@ -68,19 +73,29 @@ const NSInteger SQRLZipArchiverShellTaskFailed = 1;
 
 	RACSubject *errorDataChunks = [[RACSubject subject] setNameWithFormat:@"errorDataChunks"];
 	self.standardErrorPipe.fileHandleForReading.readabilityHandler = ^(NSFileHandle *handle) {
-		[errorDataChunks sendNext:handle.availableData];
+		NSData *data = handle.availableData;
+		if (data.length == 0) {
+			handle.readabilityHandler = nil;
+			return;
+		}
+
+		[errorDataChunks sendNext:data];
 	};
 
-	_standardErrorData = [[[[[[errorDataChunks
+	_standardErrorData = [[[[[errorDataChunks
 		takeUntil:self.taskTerminated]
-		collect]
-		flattenMap:^(NSArray *chunks) {
-			NSMutableData *combined = [NSMutableData data];
-			for (NSData *data in chunks) {
-				[combined appendData:data];
+		aggregateWithStartFactory:^id {
+			return [NSMutableData data];
+		} reduce:^id(NSMutableData *combined, NSData *data) {
+			if (combined.length >= kSQRLZipArchiverMaximumStandardErrorDataLength || data.length == 0) {
+				return combined;
 			}
 
-			return [RACSignal return:combined];
+			NSUInteger remainingLength =
+				kSQRLZipArchiverMaximumStandardErrorDataLength - combined.length;
+			NSUInteger appendLength = MIN(data.length, remainingLength);
+			[combined appendBytes:data.bytes length:appendLength];
+			return combined;
 		}]
 		repeat]
 		takeUntil:self.rac_willDeallocSignal]

--- a/SquirrelTests/SQRLZipArchiverSpec.m
+++ b/SquirrelTests/SQRLZipArchiverSpec.m
@@ -64,6 +64,26 @@ it(@"should fail to extract a nonexistent zip archive", ^{
 	expect(error.userInfo[SQRLZipArchiverExitCodeErrorKey]).notTo(equal(0));
 });
 
+it(@"should bound error output retained from a failed task", ^{
+	SQRLZipArchiver *archiver = [[SQRLZipArchiver alloc] init];
+	archiver.dittoTask.launchPath = @"/bin/sh";
+
+	NSError *error = nil;
+	BOOL success = [[archiver
+		launchWithArguments:@[
+			@"-c",
+			@"/usr/bin/yes x | /usr/bin/head -c 2097152 >&2; exit 1",
+		]]
+		asynchronouslyWaitUntilCompleted:&error];
+
+	expect(@(success)).to(beFalsy());
+	expect(error.domain).to(equal(SQRLZipArchiverErrorDomain));
+
+	NSString *errorString = error.userInfo[NSLocalizedDescriptionKey];
+	expect(errorString).notTo(beNil());
+	expect(@(errorString.length)).to(beLessThanOrEqualTo(@(1024 * 1024)));
+});
+
 it(@"should create a zip archive readable by itself", ^{
 	NSURL *zipURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:@"TestApplication.zip"];
 


### PR DESCRIPTION
## Summary

- Replace unbounded `RACSignal collect` stderr accumulation with a streaming
  aggregate that retains at most 1 MiB per `ditto` invocation.
- Stop the readability handler after EOF, avoiding unnecessary empty-pipe work.
- Add a regression test that makes a failing task emit 2 MiB on stderr and
  verifies that the retained error text is capped.

## Root cause

`SQRLZipArchiver` forwards every `NSFileHandle.availableData` callback into a
`RACSubject`. `collect` retains every chunk in an `NSMutableArray`, after which
the code concatenates all chunks into another `NSMutableData`. A malformed
archive can make `ditto` write excessive diagnostics and cause an unbounded
allocation in the host process.

### Observed crash path (root-cause-relevant frames)

```
[Chromium / PartitionAlloc
 base/allocator/partition_allocator]
partition_alloc::internal::OnNoMemoryInternal
partition_alloc::internal::TerminateBecauseOutOfMemory
partition_alloc::internal::OnNoMemory
partition_alloc::internal::PartitionExcessiveAllocationSize
partition_alloc::internal::PartitionDirectMap

[Chromium / allocator shim]
allocator shim allocation path

[Apple Foundation]
-[__NSArrayM insertObject:atIndex:]

[ReactiveObjC
 ReactiveObjC/RACSignal+Operations.m]
-[RACSignal collect]

[Squirrel.Mac
 Squirrel/SQRLZipArchiver.m]
__23-[SQRLZipArchiver init]_block_invoke.44

[Apple Foundation]
-[NSConcreteFileHandle _monitor]
```

`PartitionExcessiveAllocationSize` is a deliberate PartitionAlloc termination
when one allocation exceeds the direct-map limit (roughly 2 GiB), rather than a
generic low-memory termination. Here the unbounded `collect` array is the
allocation owner; the Foundation frame is where that array growth reaches the
allocator.

The error output is used only to populate `NSLocalizedDescription` when the
`ditto` task exits unsuccessfully. Exit status and normal archive behavior are
unchanged. The first 1 MiB of diagnostics is retained; later data is still read
and discarded so the child process cannot block on a full stderr pipe.

## Validation

- `script/test -derivedDataPath DerivedData`
  - 88 tests passed, including the new 2 MiB stderr regression test.
