### PR TITLE
fix: bound zip archiver standard error collection

### DIFF
--- a/Squirrel/SQRLZipArchiver.m
+++ b/Squirrel/SQRLZipArchiver.m
@@ -14,6 +14,11 @@ NSString * const SQRLZipArchiverErrorDomain = @"SQRLZipArchiverErrorDomain";
 NSString * const SQRLZipArchiverExitCodeErrorKey = @"SQRLZipArchiverExitCodeErrorKey";
 const NSInteger SQRLZipArchiverShellTaskFailed = 1;
 
+// `ditto` writes diagnostics for input it cannot process. Keep the retained
+// untrusted output bounded so a failed archive operation cannot exhaust memory.
+static const NSUInteger kSQRLZipArchiverMaximumStandardErrorDataLength =
+	1024 * 1024;
+
 @interface SQRLZipArchiver () {
 	RACSubject *_taskTerminated;
 }
@@ -30,8 +35,8 @@ const NSInteger SQRLZipArchiverShellTaskFailed = 1;
 // A pipe used for reading error logging from `dittoTask`.
 @property (nonatomic, strong, readonly) NSPipe *standardErrorPipe;
 
-// Sends an NSData representing the error logging from `dittoTask` once the task
-// has terminated.
+// Sends up to 1 MiB of error logging from `dittoTask` once the task has
+// terminated.
 @property (nonatomic, strong, readonly) RACSignal *standardErrorData;
 
 // Launches the receiver's `dittoTask` with the given command line arguments.
@@ -68,19 +73,29 @@ const NSInteger SQRLZipArchiverShellTaskFailed = 1;
 
 	RACSubject *errorDataChunks = [[RACSubject subject] setNameWithFormat:@"errorDataChunks"];
 	self.standardErrorPipe.fileHandleForReading.readabilityHandler = ^(NSFileHandle *handle) {
-		[errorDataChunks sendNext:handle.availableData];
+		NSData *data = handle.availableData;
+		if (data.length == 0) {
+			handle.readabilityHandler = nil;
+			return;
+		}
+
+		[errorDataChunks sendNext:data];
 	};
 
-	_standardErrorData = [[[[[[errorDataChunks
+	_standardErrorData = [[[[[errorDataChunks
 		takeUntil:self.taskTerminated]
-		collect]
-		flattenMap:^(NSArray *chunks) {
-			NSMutableData *combined = [NSMutableData data];
-			for (NSData *data in chunks) {
-				[combined appendData:data];
+		aggregateWithStartFactory:^id {
+			return [NSMutableData data];
+		} reduce:^id(NSMutableData *combined, NSData *data) {
+			if (combined.length >= kSQRLZipArchiverMaximumStandardErrorDataLength || data.length == 0) {
+				return combined;
 			}
 
-			return [RACSignal return:combined];
+			NSUInteger remainingLength =
+				kSQRLZipArchiverMaximumStandardErrorDataLength - combined.length;
+			NSUInteger appendLength = MIN(data.length, remainingLength);
+			[combined appendBytes:data.bytes length:appendLength];
+			return combined;
 		}]
 		repeat]
 		takeUntil:self.rac_willDeallocSignal]

--- a/Squirrel/SQRLZipArchiver.m
+++ b/Squirrel/SQRLZipArchiver.m
@@ -16,8 +16,29 @@ const NSInteger SQRLZipArchiverShellTaskFailed = 1;
 
 // `ditto` writes diagnostics for input it cannot process. Keep the retained
 // untrusted output bounded so a failed archive operation cannot exhaust memory.
-static const NSUInteger kSQRLZipArchiverMaximumStandardErrorDataLength =
-	1024 * 1024;
+static const NSUInteger SQRLZipArchiverMaximumStandardErrorDataLength = 1024 * 1024;
+
+static NSUInteger SQRLUTF8TruncationBoundary(const uint8_t *bytes, NSUInteger length) {
+	NSUInteger codePointStart = length;
+	while (codePointStart > 0 && (bytes[codePointStart - 1] & 0xC0) == 0x80) {
+		codePointStart--;
+	}
+
+	if (codePointStart == 0) return 0;
+
+	codePointStart--;
+	uint8_t leadingByte = bytes[codePointStart];
+	NSUInteger codePointLength = 1;
+	if ((leadingByte & 0xE0) == 0xC0) {
+		codePointLength = 2;
+	} else if ((leadingByte & 0xF0) == 0xE0) {
+		codePointLength = 3;
+	} else if ((leadingByte & 0xF8) == 0xF0) {
+		codePointLength = 4;
+	}
+
+	return codePointStart + codePointLength <= length ? length : codePointStart;
+}
 
 @interface SQRLZipArchiver () {
 	RACSubject *_taskTerminated;
@@ -82,20 +103,33 @@ static const NSUInteger kSQRLZipArchiverMaximumStandardErrorDataLength =
 		[errorDataChunks sendNext:data];
 	};
 
-	_standardErrorData = [[[[[errorDataChunks
+	_standardErrorData = [[[[[[errorDataChunks
 		takeUntil:self.taskTerminated]
 		aggregateWithStartFactory:^id {
-			return [NSMutableData data];
-		} reduce:^id(NSMutableData *combined, NSData *data) {
-			if (combined.length >= kSQRLZipArchiverMaximumStandardErrorDataLength || data.length == 0) {
-				return combined;
+			return [@{
+				@"data": [NSMutableData data],
+				@"truncated": @NO,
+			} mutableCopy];
+		} reduce:^id(NSMutableDictionary *aggregate, NSData *data) {
+			if ([aggregate[@"truncated"] boolValue]) {
+				return aggregate;
 			}
 
+			NSMutableData *combined = aggregate[@"data"];
 			NSUInteger remainingLength =
-				kSQRLZipArchiverMaximumStandardErrorDataLength - combined.length;
+				SQRLZipArchiverMaximumStandardErrorDataLength - combined.length;
 			NSUInteger appendLength = MIN(data.length, remainingLength);
 			[combined appendBytes:data.bytes length:appendLength];
-			return combined;
+
+			if (appendLength < data.length) {
+				combined.length = SQRLUTF8TruncationBoundary(combined.bytes, combined.length);
+				aggregate[@"truncated"] = @YES;
+			}
+
+			return aggregate;
+		}]
+		map:^id(NSDictionary *aggregate) {
+			return aggregate[@"data"];
 		}]
 		repeat]
 		takeUntil:self.rac_willDeallocSignal]

--- a/SquirrelTests/SQRLZipArchiverSpec.m
+++ b/SquirrelTests/SQRLZipArchiverSpec.m
@@ -67,12 +67,16 @@ it(@"should fail to extract a nonexistent zip archive", ^{
 it(@"should bound error output retained from a failed task", ^{
 	SQRLZipArchiver *archiver = [[SQRLZipArchiver alloc] init];
 	archiver.dittoTask.launchPath = @"/bin/sh";
+	NSString *command = [NSString stringWithFormat:@"%@%@%@",
+		@"/usr/bin/yes x | /usr/bin/head -c 1048575 >&2; ",
+		@"printf '\\360\\237\\230\\200' >&2; ",
+		@"/usr/bin/yes x | /usr/bin/head -c 1048576 >&2; exit 1"];
 
 	NSError *error = nil;
 	BOOL success = [[archiver
 		launchWithArguments:@[
 			@"-c",
-			@"/usr/bin/yes x | /usr/bin/head -c 2097152 >&2; exit 1",
+			command,
 		]]
 		asynchronouslyWaitUntilCompleted:&error];
 
@@ -81,6 +85,7 @@ it(@"should bound error output retained from a failed task", ^{
 
 	NSString *errorString = error.userInfo[NSLocalizedDescriptionKey];
 	expect(errorString).notTo(beNil());
+	expect(@(errorString.length)).to(beGreaterThan(@(512 * 1024)));
 	expect(@(errorString.length)).to(beLessThanOrEqualTo(@(1024 * 1024)));
 });
 

--- a/SquirrelTests/SQRLZipArchiverSpec.m
+++ b/SquirrelTests/SQRLZipArchiverSpec.m
@@ -64,6 +64,26 @@ it(@"should fail to extract a nonexistent zip archive", ^{
 	expect(error.userInfo[SQRLZipArchiverExitCodeErrorKey]).notTo(equal(0));
 });
 
+it(@"should bound error output retained from a failed task", ^{
+	SQRLZipArchiver *archiver = [[SQRLZipArchiver alloc] init];
+	archiver.dittoTask.launchPath = @"/bin/sh";
+
+	NSError *error = nil;
+	BOOL success = [[archiver
+		launchWithArguments:@[
+			@"-c",
+			@"/usr/bin/yes x | /usr/bin/head -c 2097152 >&2; exit 1",
+		]]
+		asynchronouslyWaitUntilCompleted:&error];
+
+	expect(@(success)).to(beFalsy());
+	expect(error.domain).to(equal(SQRLZipArchiverErrorDomain));
+
+	NSString *errorString = error.userInfo[NSLocalizedDescriptionKey];
+	expect(errorString).notTo(beNil());
+	expect(@(errorString.length)).to(beLessThanOrEqualTo(@(1024 * 1024)));
+});
+
 it(@"should create a zip archive readable by itself", ^{
 	NSURL *zipURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:@"TestApplication.zip"];
 


### PR DESCRIPTION
## Summary

- Replace unbounded `RACSignal collect` stderr accumulation with a streaming
  aggregate that retains at most 1 MiB per `ditto` invocation.
- Stop the readability handler after EOF, avoiding unnecessary empty-pipe work.
- Add a regression test that makes a failing task emit 2 MiB on stderr and
  verifies that the retained error text is capped.

## Root cause

`SQRLZipArchiver` forwards every `NSFileHandle.availableData` callback into a
`RACSubject`. `collect` retains every chunk in an `NSMutableArray`, after which
the code concatenates all chunks into another `NSMutableData`. A malformed
archive can make `ditto` write excessive diagnostics and cause an unbounded
allocation in the host process.

### Observed crash path (root-cause-relevant frames)

```
[Chromium / PartitionAlloc
 base/allocator/partition_allocator]
partition_alloc::internal::OnNoMemoryInternal
partition_alloc::internal::TerminateBecauseOutOfMemory
partition_alloc::internal::OnNoMemory
partition_alloc::internal::PartitionExcessiveAllocationSize
partition_alloc::internal::PartitionDirectMap

[Chromium / allocator shim]
allocator shim allocation path

[Apple Foundation]
-[__NSArrayM insertObject:atIndex:]

[ReactiveObjC
 ReactiveObjC/RACSignal+Operations.m]
-[RACSignal collect]

[Squirrel.Mac
 Squirrel/SQRLZipArchiver.m]
__23-[SQRLZipArchiver init]_block_invoke.44

[Apple Foundation]
-[NSConcreteFileHandle _monitor]
```

`PartitionExcessiveAllocationSize` is a deliberate PartitionAlloc termination
when one allocation exceeds the direct-map limit (roughly 2 GiB), rather than a
generic low-memory termination. Here the unbounded `collect` array is the
allocation owner; the Foundation frame is where that array growth reaches the
allocator.

The error output is used only to populate `NSLocalizedDescription` when the
`ditto` task exits unsuccessfully. Exit status and normal archive behavior are
unchanged. The first 1 MiB of diagnostics is retained; later data is still read
and discarded so the child process cannot block on a full stderr pipe.
