### PR TITLE
feat: stream update downloads to disk, resume them, and verify a declared digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,9 @@ to the update request provided:
 	"url": "https://mycompany.example.com/myapp/releases/myrelease",
 	"name": "My Release Name",
 	"notes": "Theses are some release notes innit",
-	"pub_date": "2013-09-18T12:29:53+01:00"
+	"pub_date": "2013-09-18T12:29:53+01:00",
+	"sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+	"size": 104857600
 }
 ```
 
@@ -171,6 +173,16 @@ will be added to the `Accept` header so that your server can return the
 appropriate format.
 
 "pub_date" if present must be formatted according to ISO 8601.
+
+"sha256" (hex) and "size" (bytes), if present, describe the ZIP at "url"; a
+download that does not match them is discarded before it is opened and the
+check fails with `SQRLUpdaterErrorInvalidUpdatePackage`.
+
+The ZIP is streamed to disk. If the transfer is interrupted (network loss,
+sleep, the app quitting) and the server answered with an `ETag` or
+`Last-Modified` and honours `Range`, the next check continues from where it
+stopped instead of starting over, including after a relaunch. Progress is
+available on `SQRLUpdater.downloadProgress`.
 
 ## Update File JSON Format
 
@@ -227,6 +239,7 @@ file); a single entry is fine.
 | `updateTo.url` | ✅ | Direct URL to the `.zip` for that version. |
 | `updateTo.version` | — | Echoed into the `update-downloaded` event; conventionally the same as the outer `version`. |
 | `updateTo.name` / `notes` / `pub_date` | — | Surfaced to your app for display. `pub_date` must be ISO 8601 if present. |
+| `updateTo.sha256` / `size` | — | Digest (hex) and byte size of the `.zip`; a download that does not match is rejected. |
 
 Point the updater directly at this file's URL — there's no required filename.
 

--- a/Squirrel.xcodeproj/project.pbxproj
+++ b/Squirrel.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		D000218F17BACEFF0050109A /* SQRLZipArchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = D000218D17BACEFF0050109A /* SQRLZipArchiver.m */; };
 		D000219717BAD34D0050109A /* TestApplication.app.zip in Resources */ = {isa = PBXBuildFile; fileRef = D000219617BAD34D0050109A /* TestApplication.app.zip */; };
 		D000219917BAD35C0050109A /* SQRLZipArchiverSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D000219817BAD35C0050109A /* SQRLZipArchiverSpec.m */; };
+		D0F0A00126500005000D0AD1 /* SQRLDownloaderSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A00126500006000D0AD1 /* SQRLDownloaderSpec.m */; };
+		D0F0A00126500007000D0AD1 /* TestServer.py in Resources */ = {isa = PBXBuildFile; fileRef = D0F0A00126500008000D0AD1 /* TestServer.py */; };
 		D00F5B8B17E82D15009A4818 /* NSProcessInfo+SQRLVersionExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D00F5B8917E82D15009A4818 /* NSProcessInfo+SQRLVersionExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D00F5B8C17E82D15009A4818 /* NSProcessInfo+SQRLVersionExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D00F5B8A17E82D15009A4818 /* NSProcessInfo+SQRLVersionExtensions.m */; };
 		D00F5B8E17E82DE6009A4818 /* NSProcessInfoExtensionsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D00F5B8D17E82DE6009A4818 /* NSProcessInfoExtensionsSpec.m */; };
@@ -83,6 +85,8 @@
 		D0C22BF5179CC00E00158214 /* Squirrel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0C22BD7179CC00E00158214 /* Squirrel.framework */; };
 		D0C22C4C179CC15100158214 /* SQRLUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = D0C22C4A179CC15100158214 /* SQRLUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0C22C4D179CC15100158214 /* SQRLUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C22C4B179CC15100158214 /* SQRLUpdater.m */; };
+		D0F0A00126500001000D0AD1 /* SQRLDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = D0F0A00126500003000D0AD1 /* SQRLDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D0F0A00126500002000D0AD1 /* SQRLDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A00126500004000D0AD1 /* SQRLDownloader.m */; };
 		D0C22C50179CC18C00158214 /* SQRLUpdaterSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C22C4F179CC18C00158214 /* SQRLUpdaterSpec.m */; };
 		D0C22C52179CC23900158214 /* Squirrel.h in Headers */ = {isa = PBXBuildFile; fileRef = D0C22BE7179CC00E00158214 /* Squirrel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0D2B6261804E903000EA901 /* SQRLDirectoryManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D0D2B6241804E903000EA901 /* SQRLDirectoryManager.m */; };
@@ -234,6 +238,8 @@
 		D000218D17BACEFF0050109A /* SQRLZipArchiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLZipArchiver.m; sourceTree = "<group>"; };
 		D000219617BAD34D0050109A /* TestApplication.app.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = TestApplication.app.zip; sourceTree = "<group>"; };
 		D000219817BAD35C0050109A /* SQRLZipArchiverSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLZipArchiverSpec.m; sourceTree = "<group>"; };
+		D0F0A00126500006000D0AD1 /* SQRLDownloaderSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLDownloaderSpec.m; sourceTree = "<group>"; };
+		D0F0A00126500008000D0AD1 /* TestServer.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = TestServer.py; sourceTree = "<group>"; };
 		D00F5B8917E82D15009A4818 /* NSProcessInfo+SQRLVersionExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSProcessInfo+SQRLVersionExtensions.h"; sourceTree = "<group>"; };
 		D00F5B8A17E82D15009A4818 /* NSProcessInfo+SQRLVersionExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSProcessInfo+SQRLVersionExtensions.m"; sourceTree = "<group>"; };
 		D00F5B8D17E82DE6009A4818 /* NSProcessInfoExtensionsSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSProcessInfoExtensionsSpec.m; sourceTree = "<group>"; };
@@ -303,6 +309,8 @@
 		D0C22C1C179CC02E00158214 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 		D0C22C4A179CC15100158214 /* SQRLUpdater.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQRLUpdater.h; sourceTree = "<group>"; };
 		D0C22C4B179CC15100158214 /* SQRLUpdater.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLUpdater.m; sourceTree = "<group>"; };
+		D0F0A00126500003000D0AD1 /* SQRLDownloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQRLDownloader.h; sourceTree = "<group>"; };
+		D0F0A00126500004000D0AD1 /* SQRLDownloader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLDownloader.m; sourceTree = "<group>"; };
 		D0C22C4F179CC18C00158214 /* SQRLUpdaterSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLUpdaterSpec.m; sourceTree = "<group>"; };
 		D0D2B6231804E903000EA901 /* SQRLDirectoryManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQRLDirectoryManager.h; sourceTree = "<group>"; };
 		D0D2B6241804E903000EA901 /* SQRLDirectoryManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLDirectoryManager.m; sourceTree = "<group>"; };
@@ -521,6 +529,8 @@
 			children = (
 				D0C22C4A179CC15100158214 /* SQRLUpdater.h */,
 				D0C22C4B179CC15100158214 /* SQRLUpdater.m */,
+				D0F0A00126500003000D0AD1 /* SQRLDownloader.h */,
+				D0F0A00126500004000D0AD1 /* SQRLDownloader.m */,
 				53AACF4917E9CA0500B41027 /* SQRLUpdate.h */,
 				53AACF4A17E9CA0500B41027 /* SQRLUpdate.m */,
 				D0964B3617F2E01500D88BF7 /* SQRLDownloadedUpdate.h */,
@@ -663,6 +673,7 @@
 				D049059E180558B7004E683E /* SQRLTestUpdate.h */,
 				D049059F180558B7004E683E /* SQRLTestUpdate.m */,
 				D000219617BAD34D0050109A /* TestApplication.app.zip */,
+				D0F0A00126500008000D0AD1 /* TestServer.py */,
 				D09D244917B59AB30001FAF8 /* TestApplication 2.1.app */,
 				D0C22BF8179CC00E00158214 /* SquirrelTests-Info.plist */,
 			);
@@ -757,6 +768,7 @@
 				D0C22C4F179CC18C00158214 /* SQRLUpdaterSpec.m */,
 				5395C0E217E9D013001648E8 /* SQRLUpdateSpec.m */,
 				D000219817BAD35C0050109A /* SQRLZipArchiverSpec.m */,
+				D0F0A00126500006000D0AD1 /* SQRLDownloaderSpec.m */,
 			);
 			name = Specs;
 			sourceTree = "<group>";
@@ -785,6 +797,7 @@
 				5374DCC6187AD0D8006B7056 /* SQRLAuthorization.h in Headers */,
 				D0964B3C17F2E20B00D88BF7 /* NSBundle+SQRLVersionExtensions.h in Headers */,
 				D0C22C4C179CC15100158214 /* SQRLUpdater.h in Headers */,
+				D0F0A00126500001000D0AD1 /* SQRLDownloader.h in Headers */,
 				D0C22C52179CC23900158214 /* Squirrel.h in Headers */,
 				D0964B3817F2E01500D88BF7 /* SQRLDownloadedUpdate.h in Headers */,
 				53AACF4B17E9CA0500B41027 /* SQRLUpdate.h in Headers */,
@@ -967,6 +980,7 @@
 				D08D4E4A17B451FD0012B22D /* TestApplication.app in Resources */,
 				D09D244A17B59AB30001FAF8 /* TestApplication 2.1.app in Resources */,
 				D000219717BAD34D0050109A /* TestApplication.app.zip in Resources */,
+				D0F0A00126500007000D0AD1 /* TestServer.py in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1038,6 +1052,7 @@
 				D014ABB817B96CB3007D79D0 /* SQRLShipItLauncher.m in Sources */,
 				D000218F17BACEFF0050109A /* SQRLZipArchiver.m in Sources */,
 				D0C22C4D179CC15100158214 /* SQRLUpdater.m in Sources */,
+				D0F0A00126500002000D0AD1 /* SQRLDownloader.m in Sources */,
 				D0EDBE9D17B0C68E0058BC3C /* NSError+SQRLVerbosityExtensions.m in Sources */,
 				53AACF4C17E9CA0500B41027 /* SQRLUpdate.m in Sources */,
 				5397A5CF187D92810014A477 /* SQRLShipItRequest.m in Sources */,
@@ -1053,6 +1068,7 @@
 			files = (
 				5395C0E317E9D013001648E8 /* SQRLUpdateSpec.m in Sources */,
 				D000219917BAD35C0050109A /* SQRLZipArchiverSpec.m in Sources */,
+				D0F0A00126500005000D0AD1 /* SQRLDownloaderSpec.m in Sources */,
 				D043F77E17FF43640012F996 /* SQRLTerminationListener.m in Sources */,
 				D09D244117B595470001FAF8 /* SQRLInstallerSpec.m in Sources */,
 				D0C22C50179CC18C00158214 /* SQRLUpdaterSpec.m in Sources */,

--- a/Squirrel/SQRLDownloader.h
+++ b/Squirrel/SQRLDownloader.h
@@ -1,0 +1,78 @@
+//
+//  SQRLDownloader.h
+//  Squirrel
+//
+//  Copyright (c) 2026 GitHub. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class RACSignal;
+
+// How far an in-flight download has got.
+@interface SQRLDownloadProgress : NSObject <NSCopying>
+
+// The offset this attempt started from. Zero for a fresh download, non-zero
+// when a previous partial transfer was resumed.
+@property (nonatomic, assign, readonly) int64_t bytesResumed;
+
+// Bytes on disk so far, including `bytesResumed`.
+@property (nonatomic, assign, readonly) int64_t bytesReceived;
+
+// The full size of the payload, or `NSURLSessionTransferSizeUnknown`.
+@property (nonatomic, assign, readonly) int64_t bytesExpected;
+
+- (instancetype)initWithBytesResumed:(int64_t)bytesResumed bytesReceived:(int64_t)bytesReceived bytesExpected:(int64_t)bytesExpected;
+
+@end
+
+// Downloads one URL to disk with an `NSURLSession` download task.
+//
+// The payload is streamed to a file rather than accumulated in memory. When
+// the transfer fails or is cancelled and the response allows it (an `ETag` or
+// `Last-Modified` validator), the session's resume data is written to
+// `resumeDataURL`, and the next `SQRLDownloader` created for the same URL with
+// the same `resumeDataURL` continues from that offset instead of starting
+// over. This holds across process launches: the partial file lives in the
+// user's temporary directory and the resume data names it. Resume data for a
+// different URL, or that the session no longer accepts, is discarded and the
+// download starts fresh.
+//
+// This is a one-shot object; create one per download.
+@interface SQRLDownloader : NSObject
+
+// The configuration new downloads create their session with. Defaults to
+// `NSURLSessionConfiguration.defaultSessionConfiguration`; replace it to set
+// network policy (`allowsExpensiveNetworkAccess`, proxies) or protocol
+// classes. Read when a download starts.
+@property (class, nonatomic, copy) NSURLSessionConfiguration *sessionConfiguration;
+
+// request       - The request to perform. Must not be nil.
+// resumeDataURL - A file URL at which resume data for `request` is kept
+//                 between attempts, or nil to never resume.
+- (instancetype)initWithRequest:(NSURLRequest *)request resumeDataURL:(NSURL *)resumeDataURL;
+
+// Sends `SQRLDownloadProgress` values while a download started with
+// -downloadToURL: is transferring, on an unspecified thread. Never errors;
+// completes when the download does.
+@property (nonatomic, strong, readonly) RACSignal *progress;
+
+// Starts, or resumes, the download when subscribed to.
+//
+// destinationURL - Where to move the finished payload. Anything already there
+//                  is replaced. Must not be nil.
+//
+// Returns a signal which sends a `RACTuple` of the final `NSURLResponse` and
+// `destinationURL` then completes, or errors, on an unspecified thread. HTTP
+// error statuses are not errors here; the response is passed through for the
+// caller to judge. Disposing of the subscription cancels the transfer and, like
+// a failure, keeps resume data for the next attempt.
+- (RACSignal *)downloadToURL:(NSURL *)destinationURL;
+
+// Cancels every download currently in flight in this process, writing resume
+// data for each, and returns once that is done or `timeout` has elapsed. Meant
+// for the host application's termination path so a relaunch can pick up where
+// this process left off.
++ (void)cancelAllWritingResumeDataWithTimeout:(NSTimeInterval)timeout;
+
+@end

--- a/Squirrel/SQRLDownloader.m
+++ b/Squirrel/SQRLDownloader.m
@@ -1,0 +1,305 @@
+//
+//  SQRLDownloader.m
+//  Squirrel
+//
+//  Copyright (c) 2026 GitHub. All rights reserved.
+//
+
+#import "SQRLDownloader.h"
+#import <ReactiveObjC/ReactiveObjC.h>
+
+// Keys of the property list written to `resumeDataURL`. The session's resume
+// data is opaque, so the URL it belongs to is kept beside it.
+static NSString * const SQRLDownloaderResumeURLKey = @"URL";
+static NSString * const SQRLDownloaderResumeDataKey = @"resumeData";
+
+@implementation SQRLDownloadProgress
+
+- (instancetype)initWithBytesResumed:(int64_t)bytesResumed bytesReceived:(int64_t)bytesReceived bytesExpected:(int64_t)bytesExpected {
+	self = [super init];
+	if (self == nil) return nil;
+
+	_bytesResumed = bytesResumed;
+	_bytesReceived = bytesReceived;
+	_bytesExpected = bytesExpected;
+	return self;
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+	return self;
+}
+
+- (NSString *)description {
+	return [NSString stringWithFormat:@"<%@: %p>{ resumed = %lld, received = %lld, expected = %lld }", self.class, self, self.bytesResumed, self.bytesReceived, self.bytesExpected];
+}
+
+@end
+
+@interface SQRLDownloader () <NSURLSessionDownloadDelegate>
+
+@property (nonatomic, copy, readonly) NSURLRequest *request;
+@property (nonatomic, copy, readonly) NSURL *resumeDataURL;
+
+// Serial queue every delegate callback arrives on; all mutable state below is
+// touched only there once the task has started.
+@property (nonatomic, strong, readonly) NSOperationQueue *delegateQueue;
+@property (nonatomic, strong) NSURLSession *session;
+@property (nonatomic, strong) NSURLSessionDownloadTask *task;
+
+@property (nonatomic, strong) id<RACSubscriber> subscriber;
+@property (nonatomic, copy) NSURL *destinationURL;
+@property (nonatomic, strong) NSError *moveError;
+
+@property (nonatomic, assign) int64_t bytesResumed;
+@property (nonatomic, assign) BOOL startedFromResumeData;
+@property (nonatomic, assign) BOOL retriedFresh;
+@property (nonatomic, assign) BOOL cancelled;
+
+// Entered when a task starts, left when its completion (including any resume
+// data write) has been handled. +cancelAllWritingResumeDataWithTimeout: waits
+// on it.
+@property (nonatomic, strong, readonly) dispatch_group_t completionGroup;
+
+@end
+
+@implementation SQRLDownloader {
+	RACSubject *_progress;
+}
+
+#pragma mark Configuration
+
+static NSURLSessionConfiguration *SQRLDownloaderSessionConfiguration = nil;
+
++ (NSURLSessionConfiguration *)sessionConfiguration {
+	@synchronized (self) {
+		return [SQRLDownloaderSessionConfiguration copy] ?: NSURLSessionConfiguration.defaultSessionConfiguration;
+	}
+}
+
++ (void)setSessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration {
+	@synchronized (self) {
+		SQRLDownloaderSessionConfiguration = [sessionConfiguration copy];
+	}
+}
+
+#pragma mark Registry
+
++ (NSHashTable *)liveDownloaders {
+	static NSHashTable *live;
+	static dispatch_once_t once;
+	dispatch_once(&once, ^{
+		live = [NSHashTable weakObjectsHashTable];
+	});
+	return live;
+}
+
++ (void)cancelAllWritingResumeDataWithTimeout:(NSTimeInterval)timeout {
+	NSArray *downloaders;
+	NSHashTable *live = self.liveDownloaders;
+	@synchronized (live) {
+		downloaders = live.allObjects;
+	}
+
+	dispatch_group_t all = dispatch_group_create();
+	for (SQRLDownloader *downloader in downloaders) {
+		dispatch_group_enter(all);
+		dispatch_group_notify(downloader.completionGroup, dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+			dispatch_group_leave(all);
+		});
+		[downloader cancel];
+	}
+
+	dispatch_group_wait(all, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC)));
+}
+
+#pragma mark Lifecycle
+
+- (instancetype)initWithRequest:(NSURLRequest *)request resumeDataURL:(NSURL *)resumeDataURL {
+	NSParameterAssert(request != nil);
+	NSParameterAssert(resumeDataURL == nil || resumeDataURL.isFileURL);
+
+	self = [super init];
+	if (self == nil) return nil;
+
+	_request = [request copy];
+	_resumeDataURL = [resumeDataURL copy];
+	_progress = [[RACSubject subject] setNameWithFormat:@"%@ progress", self];
+	_completionGroup = dispatch_group_create();
+
+	_delegateQueue = [[NSOperationQueue alloc] init];
+	_delegateQueue.maxConcurrentOperationCount = 1;
+	_delegateQueue.name = @"com.github.Squirrel.SQRLDownloader";
+
+	return self;
+}
+
+- (RACSignal *)progress {
+	return _progress;
+}
+
+#pragma mark Resume Data
+
+- (NSData *)takeStoredResumeData {
+	if (self.resumeDataURL == nil) return nil;
+
+	NSDictionary *stored = [NSDictionary dictionaryWithContentsOfURL:self.resumeDataURL];
+	NSData *resumeData = stored[SQRLDownloaderResumeDataKey];
+	if (![stored[SQRLDownloaderResumeURLKey] isEqual:self.request.URL.absoluteString] || ![resumeData isKindOfClass:NSData.class]) {
+		[self clearStoredResumeData];
+		return nil;
+	}
+
+	return resumeData;
+}
+
+- (void)storeResumeData:(NSData *)resumeData {
+	if (self.resumeDataURL == nil) return;
+	if (resumeData == nil) {
+		[self clearStoredResumeData];
+		return;
+	}
+
+	NSDictionary *stored = @{
+		SQRLDownloaderResumeURLKey: self.request.URL.absoluteString,
+		SQRLDownloaderResumeDataKey: resumeData,
+	};
+
+	NSError *error;
+	NSData *plist = [NSPropertyListSerialization dataWithPropertyList:stored format:NSPropertyListBinaryFormat_v1_0 options:0 error:&error];
+	if (plist == nil || ![plist writeToURL:self.resumeDataURL options:NSDataWritingAtomic error:&error]) {
+		NSLog(@"Could not keep resume data for %@ at %@: %@", self.request.URL, self.resumeDataURL, error);
+	}
+}
+
+- (void)clearStoredResumeData {
+	if (self.resumeDataURL == nil) return;
+	[NSFileManager.defaultManager removeItemAtURL:self.resumeDataURL error:NULL];
+}
+
+#pragma mark Downloading
+
+- (RACSignal *)downloadToURL:(NSURL *)destinationURL {
+	NSParameterAssert(destinationURL != nil);
+
+	return [[RACSignal
+		createSignal:^(id<RACSubscriber> subscriber) {
+			NSAssert(self.session == nil, @"%@ is one-shot; -downloadToURL: was subscribed to twice", self);
+
+			self.subscriber = subscriber;
+			self.destinationURL = destinationURL;
+			self.session = [NSURLSession sessionWithConfiguration:self.class.sessionConfiguration delegate:self delegateQueue:self.delegateQueue];
+
+			NSHashTable *live = self.class.liveDownloaders;
+			@synchronized (live) {
+				[live addObject:self];
+			}
+
+			[self.delegateQueue addOperationWithBlock:^{
+				[self startTaskWithResumeData:[self takeStoredResumeData]];
+			}];
+
+			return [RACDisposable disposableWithBlock:^{
+				[self cancel];
+			}];
+		}]
+		setNameWithFormat:@"%@ -downloadToURL: %@", self, destinationURL];
+}
+
+- (void)startTaskWithResumeData:(NSData *)resumeData {
+	dispatch_group_enter(self.completionGroup);
+
+	self.startedFromResumeData = (resumeData != nil);
+	self.bytesResumed = 0;
+	self.moveError = nil;
+	self.task = self.startedFromResumeData ? [self.session downloadTaskWithResumeData:resumeData] : [self.session downloadTaskWithRequest:self.request];
+	[self.task resume];
+}
+
+- (void)cancel {
+	[self.delegateQueue addOperationWithBlock:^{
+		if (self.task == nil || self.cancelled) return;
+
+		self.cancelled = YES;
+		// The resume data also arrives in -URLSession:task:didCompleteWithError:,
+		// which is where it is written.
+		[self.task cancelByProducingResumeData:^(NSData *resumeData) {}];
+	}];
+}
+
+- (void)sendProgressWithBytesReceived:(int64_t)bytesReceived bytesExpected:(int64_t)bytesExpected {
+	[_progress sendNext:[[SQRLDownloadProgress alloc] initWithBytesResumed:self.bytesResumed bytesReceived:bytesReceived bytesExpected:bytesExpected]];
+}
+
+#pragma mark NSURLSessionDownloadDelegate
+
+- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didResumeAtOffset:(int64_t)fileOffset expectedTotalBytes:(int64_t)expectedTotalBytes {
+	self.bytesResumed = fileOffset;
+	[self sendProgressWithBytesReceived:fileOffset bytesExpected:expectedTotalBytes];
+}
+
+- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didWriteData:(int64_t)bytesWritten totalBytesWritten:(int64_t)totalBytesWritten totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
+	[self sendProgressWithBytesReceived:totalBytesWritten bytesExpected:totalBytesExpectedToWrite];
+}
+
+- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location {
+	NSFileManager *fileManager = [[NSFileManager alloc] init];
+	[fileManager removeItemAtURL:self.destinationURL error:NULL];
+
+	NSError *error;
+	if (![fileManager moveItemAtURL:location toURL:self.destinationURL error:&error]) {
+		self.moveError = error;
+	}
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error {
+	if (task != self.task) return;
+
+	if (error != nil) {
+		NSData *resumeData = error.userInfo[NSURLSessionDownloadTaskResumeData];
+		[self storeResumeData:resumeData];
+
+		// Resume data the session refused (stale temporary file, format it no
+		// longer reads): don't lose this attempt to it, start over once.
+		if (resumeData == nil && self.startedFromResumeData && !self.retriedFresh && !self.cancelled) {
+			self.retriedFresh = YES;
+			dispatch_group_leave(self.completionGroup);
+			[self startTaskWithResumeData:nil];
+			return;
+		}
+
+		[self finishWithError:error];
+		return;
+	}
+
+	if (self.moveError != nil) {
+		[self clearStoredResumeData];
+		[self finishWithError:self.moveError];
+		return;
+	}
+
+	[self clearStoredResumeData];
+	[self.subscriber sendNext:RACTuplePack(task.response, self.destinationURL)];
+	[self finishWithError:nil];
+}
+
+- (void)finishWithError:(NSError *)error {
+	id<RACSubscriber> subscriber = self.subscriber;
+	self.subscriber = nil;
+
+	[self.session finishTasksAndInvalidate];
+	NSHashTable *live = self.class.liveDownloaders;
+	@synchronized (live) {
+		[live removeObject:self];
+	}
+
+	[_progress sendCompleted];
+	if (error != nil) {
+		[subscriber sendError:error];
+	} else {
+		[subscriber sendCompleted];
+	}
+
+	dispatch_group_leave(self.completionGroup);
+}
+
+@end

--- a/Squirrel/SQRLUpdate.h
+++ b/Squirrel/SQRLUpdate.h
@@ -28,4 +28,13 @@
 // The URL to the update package that should be downloaded for installation.
 @property (readonly, copy, nonatomic) NSURL *updateURL;
 
+// The SHA-256 digest of the update package, as lowercase hex, if the server
+// declared one. A downloaded package that does not match it is rejected before
+// it is opened.
+@property (readonly, copy, nonatomic) NSString *packageDigest;
+
+// The size of the update package in bytes, if the server declared one. A
+// downloaded package of any other size is rejected before it is opened.
+@property (readonly, copy, nonatomic) NSNumber *packageSize;
+
 @end

--- a/Squirrel/SQRLUpdate.m
+++ b/Squirrel/SQRLUpdate.m
@@ -65,6 +65,8 @@ NSString * const SQRLUpdateJSONPublicationDateKey = @"pub_date";
 		@keypath(SQRLUpdate.new, releaseName): @"name",
 		@keypath(SQRLUpdate.new, releaseDate): @"pub_date",
 		@keypath(SQRLUpdate.new, updateURL): @"url",
+		@keypath(SQRLUpdate.new, packageDigest): @"sha256",
+		@keypath(SQRLUpdate.new, packageSize): @"size",
 	};
 }
 
@@ -105,6 +107,27 @@ NSString * const SQRLUpdateJSONPublicationDateKey = @"pub_date";
 }
 
 #pragma mark NSKeyValueCoding
+
+- (BOOL)validatePackageDigest:(NSString **)stringPtr error:(NSError **)error {
+	if (*stringPtr == nil) return YES;
+	if (![self validateString:*stringPtr forKey:@keypath(self.packageDigest) error:error]) return NO;
+
+	*stringPtr = [*stringPtr lowercaseString];
+	return YES;
+}
+
+- (BOOL)validatePackageSize:(NSNumber **)sizePtr error:(NSError **)error {
+	if (*sizePtr == nil || [*sizePtr isKindOfClass:NSNumber.class]) return YES;
+
+	if (error != NULL) {
+		NSDictionary *userInfo = @{
+			NSLocalizedDescriptionKey: NSLocalizedString(@"Validation failed", nil),
+			NSLocalizedRecoverySuggestionErrorKey: [NSString stringWithFormat:NSLocalizedString(@"An invalid size was given to SQRLUpdate: %@", nil), *sizePtr]
+		};
+		*error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSKeyValueValidationError userInfo:userInfo];
+	}
+	return NO;
+}
 
 - (BOOL)validateReleaseName:(NSString **)stringPtr error:(NSError **)error {
 	if (![self validateString:*stringPtr forKey:@keypath(self.releaseName) error:error]) {

--- a/Squirrel/SQRLUpdater.h
+++ b/Squirrel/SQRLUpdater.h
@@ -55,6 +55,10 @@ extern const NSInteger SQRLUpdaterErrorInvalidServerBody;
 // Includes `SQRLUpdaterJSONObjectErrorKey` in the error's `userInfo`.
 extern const NSInteger SQRLUpdaterErrorInvalidJSON;
 
+// The downloaded update package did not have the size or SHA-256 digest the
+// update declared for it.
+extern const NSInteger SQRLUpdaterErrorInvalidUpdatePackage;
+
 // Associated with the `NSData` received from the server when an error with code
 // `SQRLUpdaterErrorInvalidServerResponse` is generated.
 extern NSString * const SQRLUpdaterServerDataErrorKey;
@@ -85,6 +89,12 @@ typedef enum {
 //
 // This property is KVO-compliant.
 @property (atomic, readonly) SQRLUpdaterState state;
+
+// Sends `SQRLDownloadProgress` values on an unspecified thread while an update
+// package is being downloaded (`state` is
+// `SQRLUpdaterStateDownloadingUpdate`). A download that continues a previous
+// interrupted attempt reports the offset it started from as `bytesResumed`.
+@property (nonatomic, strong, readonly) RACSignal *downloadProgress;
 
 // Sends an `SQRLDownloadedUpdate` object on the main thread whenever a new
 // update is available.

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -14,12 +14,14 @@
 #import "SQRLCodeSignature.h"
 #import "SQRLDirectoryManager.h"
 #import "SQRLDownloadedUpdate.h"
+#import "SQRLDownloader.h"
 #import "SQRLShipItLauncher.h"
 #import "SQRLUpdate.h"
 #import "SQRLZipArchiver.h"
 #import "SQRLShipItRequest.h"
 #import <ReactiveObjC/EXTScope.h>
 #import <ReactiveObjC/ReactiveObjC.h>
+#import <CommonCrypto/CommonDigest.h>
 #import <sys/mount.h>
 
 NSString * const SQRLUpdaterErrorDomain = @"SQRLUpdaterErrorDomain";
@@ -36,11 +38,24 @@ const NSInteger SQRLUpdaterErrorInvalidServerBody = 7;
 /// The application's being run on a read-only volume.
 const NSInteger SQRLUpdaterErrorReadOnlyVolume = 8;
 
+const NSInteger SQRLUpdaterErrorInvalidUpdatePackage = 9;
+
 const NSTimeInterval SQURLUpdaterZipDownloadTimeoutSeconds = 20 * 60;
 
 // The prefix used when creating temporary directories for updates. This will be
 // followed by a random string of characters.
 static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
+
+// Kept in the storage directory, beside the per-attempt update directories, so
+// an interrupted package download can continue on a later check or launch.
+static NSString * const SQRLUpdaterResumeDataFileName = @"download.resumedata";
+
+// How much of an error response body to attach to the error.
+static const NSUInteger SQRLUpdaterServerDataErrorLimit = 64 * 1024;
+
+// How long -[NSApplication terminate:] may wait for an in-flight download to
+// hand over its resume data.
+static const NSTimeInterval SQRLUpdaterTerminationResumeDataTimeout = 2;
 
 BOOL isVersionStandard(NSString* version) {
 	NSCharacterSet *alphaNums = [NSCharacterSet decimalDigitCharacterSet];
@@ -102,6 +117,13 @@ BOOL isVersionStandard(NSString* version) {
 // errors, on a background thread.
 - (RACSignal *)downloadBundleForUpdate:(SQRLUpdate *)update intoDirectory:(NSURL *)downloadDirectory;
 
+// Checks a downloaded package against the size and digest its update declares.
+//
+// Returns a signal which completes, or errors with
+// `SQRLUpdaterErrorInvalidUpdatePackage`, on a background thread. Completes
+// immediately when the update declares neither.
+- (RACSignal *)verifyPackageAtURL:(NSURL *)packageURL forUpdate:(SQRLUpdate *)update;
+
 // Creates a unique directory in which to save the update bundle, for later use
 // by ShipIt.
 //
@@ -142,7 +164,9 @@ BOOL isVersionStandard(NSString* version) {
 
 @end
 
-@implementation SQRLUpdater
+@implementation SQRLUpdater {
+	RACSubject *_downloadProgress;
+}
 
 #pragma mark Properties
 
@@ -198,6 +222,14 @@ BOOL isVersionStandard(NSString* version) {
 	}
 	_updateRequest = mutableUpdateRequest;
 	_updateClass = SQRLUpdate.class;
+	_downloadProgress = [[RACSubject subject] setNameWithFormat:@"%@ downloadProgress", self];
+
+	[[[NSNotificationCenter.defaultCenter
+		rac_addObserverForName:NSApplicationWillTerminateNotification object:nil]
+		takeUntil:self.rac_willDeallocSignal]
+		subscribeNext:^(id _) {
+			[SQRLDownloader cancelAllWritingResumeDataWithTimeout:SQRLUpdaterTerminationResumeDataTimeout];
+		}];
 	NSError *error = nil;
 	_signature = [SQRLCodeSignature currentApplicationSignature:&error];
 	if (_signature == nil) {
@@ -468,36 +500,20 @@ BOOL isVersionStandard(NSString* version) {
 		setNameWithFormat:@"%@ -downloadAndPrepareUpdate: %@", self, update];
 }
 
-- (RACSignal *)unarchiveAndPrepareData:(NSData *)data withName:(NSString *)name intoDirectory:(NSURL *)downloadDirectory {
-	return [[[[[RACSignal
-		defer:^{
-			NSURL *zipOutputURL = [downloadDirectory URLByAppendingPathComponent:name];
+- (RACSignal *)unarchiveAndPrepareZipAtURL:(NSURL *)zipURL intoDirectory:(NSURL *)downloadDirectory {
+	return [[[[[SQRLZipArchiver
+		unzipArchiveAtURL:zipURL intoDirectoryAtURL:downloadDirectory]
+		ignoreValues]
+		doCompleted:^{
 			NSError *error = nil;
-			if ([data writeToURL:zipOutputURL options:NSDataWritingAtomic error:&error]) {
-				return [RACSignal return:zipOutputURL];
-			} else {
-				return [RACSignal error:error];
+			if (![NSFileManager.defaultManager removeItemAtURL:zipURL error:&error]) {
+				NSLog(@"Error removing downloaded archive at %@: %@", zipURL, error.sqrl_verboseDescription);
 			}
 		}]
-		doNext:^(NSURL *zipOutputURL) {
-			NSLog(@"Download completed to: %@", zipOutputURL);
-		}]
-		flattenMap:^(NSURL *zipOutputURL) {
-			return [[[[SQRLZipArchiver
-				unzipArchiveAtURL:zipOutputURL intoDirectoryAtURL:downloadDirectory]
-				ignoreValues]
-				concat:[RACSignal return:zipOutputURL]]
-				doCompleted:^{
-					NSError *error = nil;
-					if (![NSFileManager.defaultManager removeItemAtURL:zipOutputURL error:&error]) {
-						NSLog(@"Error removing downloaded archive at %@: %@", zipOutputURL, error.sqrl_verboseDescription);
-					}
-				}];
-		}]
-		flattenMap:^(NSURL *zipOutputURL) {
+		then:^{
 			return [self updateBundleMatchingCurrentApplicationInDirectory:downloadDirectory];
 		}]
-		setNameWithFormat:@"%@ -unarchiveAndPrepareData:withName: %@ intoDirectory: %@", self, name, downloadDirectory];
+		setNameWithFormat:@"%@ -unarchiveAndPrepareZipAtURL: %@ intoDirectory: %@", self, zipURL, downloadDirectory];
 }
 
 - (RACSignal *)downloadBundleForUpdate:(SQRLUpdate *)update intoDirectory:(NSURL *)downloadDirectory {
@@ -516,17 +532,28 @@ BOOL isVersionStandard(NSString* version) {
 
 			[zipDownloadRequest setTimeoutInterval:SQURLUpdaterZipDownloadTimeoutSeconds];
 
-			return [[[NSURLConnection
-				rac_sendAsynchronousRequest:zipDownloadRequest]
-				reduceEach:^(NSURLResponse *response, NSData *bodyData) {
+			NSURL *zipOutputURL = [downloadDirectory URLByAppendingPathComponent:zipDownloadURL.lastPathComponent];
+			NSURL *resumeDataURL = [downloadDirectory.URLByDeletingLastPathComponent URLByAppendingPathComponent:SQRLUpdaterResumeDataFileName];
+			SQRLDownloader *downloader = [[SQRLDownloader alloc] initWithRequest:zipDownloadRequest resumeDataURL:resumeDataURL];
+			[downloader.progress subscribeNext:^(SQRLDownloadProgress *progress) {
+				[self->_downloadProgress sendNext:progress];
+			}];
+
+			return [[[downloader
+				downloadToURL:zipOutputURL]
+				reduceEach:^(NSURLResponse *response, NSURL *zipURL) {
 					if ([response isKindOfClass:NSHTTPURLResponse.class]) {
 						NSHTTPURLResponse *httpResponse = (id)response;
 
 						if (httpResponse.statusCode == 304 /* Not Modified */) {
+							[NSFileManager.defaultManager removeItemAtURL:zipURL error:NULL];
 							return [RACSignal return:nil];
 						}
 
 						if (!(httpResponse.statusCode >= 200 && httpResponse.statusCode <= 299)) {
+							NSData *bodyData = [[NSFileHandle fileHandleForReadingFromURL:zipURL error:NULL] readDataOfLength:SQRLUpdaterServerDataErrorLimit] ?: NSData.data;
+							[NSFileManager.defaultManager removeItemAtURL:zipURL error:NULL];
+
 							NSDictionary *errorInfo = @{
 								NSLocalizedDescriptionKey: NSLocalizedString(@"Update download failed", nil),
 								NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"The server sent an invalid response. Try again later.", nil),
@@ -539,11 +566,73 @@ BOOL isVersionStandard(NSString* version) {
 						self.etag = httpResponse.allHeaderFields[@"ETag"];
 					}
 
-					return [self unarchiveAndPrepareData:bodyData withName:zipDownloadURL.lastPathComponent intoDirectory:downloadDirectory];
+					NSLog(@"Download completed to: %@", zipURL);
+					return [[self
+						verifyPackageAtURL:zipURL forUpdate:update]
+						then:^{
+							return [self unarchiveAndPrepareZipAtURL:zipURL intoDirectory:downloadDirectory];
+						}];
 				}]
 				flatten];
 		}]
 		setNameWithFormat:@"%@ -downloadBundleForUpdate: %@ intoDirectory: %@", self, update, downloadDirectory];
+}
+
+- (RACSignal *)verifyPackageAtURL:(NSURL *)packageURL forUpdate:(SQRLUpdate *)update {
+	NSParameterAssert(packageURL != nil);
+	NSParameterAssert(update != nil);
+
+	if (update.packageSize == nil && update.packageDigest == nil) return [RACSignal empty];
+
+	return [[RACSignal
+		defer:^{
+			RACSignal * (^reject)(NSString *) = ^(NSString *reason) {
+				[NSFileManager.defaultManager removeItemAtURL:packageURL error:NULL];
+
+				NSDictionary *userInfo = @{
+					NSLocalizedDescriptionKey: NSLocalizedString(@"Update download failed", nil),
+					NSLocalizedRecoverySuggestionErrorKey: reason,
+					NSURLErrorKey: update.updateURL,
+				};
+				return [RACSignal error:[NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorInvalidUpdatePackage userInfo:userInfo]];
+			};
+
+			if (update.packageSize != nil) {
+				NSNumber *size = nil;
+				[packageURL getResourceValue:&size forKey:NSURLFileSizeKey error:NULL];
+				if (![size isEqual:update.packageSize]) {
+					return reject([NSString stringWithFormat:NSLocalizedString(@"The update package is %@ bytes, expected %@.", nil), size, update.packageSize]);
+				}
+			}
+
+			if (update.packageDigest != nil) {
+				NSError *error;
+				NSFileHandle *handle = [NSFileHandle fileHandleForReadingFromURL:packageURL error:&error];
+				if (handle == nil) return [RACSignal error:error];
+
+				CC_SHA256_CTX context;
+				CC_SHA256_Init(&context);
+				for (;;) {
+					@autoreleasepool {
+						NSData *chunk = [handle readDataOfLength:1024 * 1024];
+						if (chunk.length == 0) break;
+						CC_SHA256_Update(&context, chunk.bytes, (CC_LONG)chunk.length);
+					}
+				}
+
+				unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+				CC_SHA256_Final(digest, &context);
+				NSMutableString *hex = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+				for (NSUInteger i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) [hex appendFormat:@"%02x", digest[i]];
+
+				if (![hex isEqualToString:update.packageDigest]) {
+					return reject([NSString stringWithFormat:NSLocalizedString(@"The update package digest is %@, expected %@.", nil), hex, update.packageDigest]);
+				}
+			}
+
+			return [RACSignal empty];
+		}]
+		setNameWithFormat:@"%@ -verifyPackageAtURL: %@ forUpdate: %@", self, packageURL, update];
 }
 
 #pragma mark File Management

--- a/Squirrel/Squirrel.h
+++ b/Squirrel/Squirrel.h
@@ -17,5 +17,6 @@ FOUNDATION_EXPORT const unsigned char SquirrelVersionString[];
 #import <Squirrel/NSBundle+SQRLVersionExtensions.h>
 #import <Squirrel/NSProcessInfo+SQRLVersionExtensions.h>
 #import <Squirrel/SQRLDownloadedUpdate.h>
+#import <Squirrel/SQRLDownloader.h>
 #import <Squirrel/SQRLUpdater.h>
 #import <Squirrel/SQRLUpdate.h>

--- a/SquirrelTests/QuickSpec+SQRLFixtures.h
+++ b/SquirrelTests/QuickSpec+SQRLFixtures.h
@@ -113,6 +113,17 @@ extern const NSTimeInterval SQRLLongTimeout;
 // automatically be unmounted and deleted at the end of the example.
 - (NSURL *)createAndMountDiskImageNamed:(NSString *)name fromDirectory:(NSURL *)directoryURL;
 
+// Starts an HTTP server (TestServer.py) for the files in `directoryURL`. It
+// answers byte ranges with an ETag, and `?drop=<n>` cuts the first transfer of
+// a file short after n bytes.
+//
+// requestLogURL - If not NULL, set to a file that gains one line per request:
+//                 "GET <path> Range=<header or -> If-Range=<header or ->".
+//
+// Returns the server's base URL. The server is stopped at the end of the
+// example.
+- (NSURL *)startTestServerForDirectory:(NSURL *)directoryURL requestLog:(NSURL **)requestLogURL;
+
 // Add a block to cleanup after each example has run
 //
 // Blocks are run in reverse order, i.e. LIFO

--- a/SquirrelTests/QuickSpec+SQRLFixtures.m
+++ b/SquirrelTests/QuickSpec+SQRLFixtures.m
@@ -119,6 +119,34 @@ QuickConfigurationEnd
 	[cleanupBlocks addObject:[block copy]];
 }
 
+#pragma mark Test Server
+
+- (NSURL *)startTestServerForDirectory:(NSURL *)directoryURL requestLog:(NSURL **)requestLogURL {
+	NSURL *scriptURL = [SQRLTestBundle() URLForResource:@"TestServer" withExtension:@"py"];
+	XCTAssertNotNil(scriptURL, @"Couldn't find TestServer.py in test bundle");
+
+	NSURL *logURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:[NSProcessInfo.processInfo.globallyUniqueString stringByAppendingPathExtension:@"log"]];
+	[NSData.data writeToURL:logURL atomically:YES];
+	if (requestLogURL != NULL) *requestLogURL = logURL;
+
+	NSTask *task = [[NSTask alloc] init];
+	task.launchPath = @"/usr/bin/python3";
+	task.arguments = @[ scriptURL.path, directoryURL.path, logURL.path ];
+	task.standardOutput = [NSPipe pipe];
+	[task launch];
+
+	[self addCleanupBlock:^{
+		[task terminate];
+		[task waitUntilExit];
+	}];
+
+	NSData *lineData = [[task.standardOutput fileHandleForReading] availableData];
+	NSString *line = [[NSString alloc] initWithData:lineData encoding:NSUTF8StringEncoding];
+	XCTAssertTrue([line hasPrefix:@"PORT "], @"TestServer.py did not report a port: %@", line);
+
+	return [NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", [line substringFromIndex:5].intValue]];
+}
+
 #pragma mark Temporary Directory
 
 - (NSURL *)baseTemporaryDirectoryURL {

--- a/SquirrelTests/SQRLDownloaderSpec.m
+++ b/SquirrelTests/SQRLDownloaderSpec.m
@@ -1,0 +1,131 @@
+//
+//  SQRLDownloaderSpec.m
+//  Squirrel
+//
+//  Copyright (c) 2026 GitHub. All rights reserved.
+//
+
+#import <Nimble/Nimble.h>
+#import <Quick/Quick.h>
+#import <ReactiveObjC/ReactiveObjC.h>
+#import <Squirrel/Squirrel.h>
+
+#import "QuickSpec+SQRLFixtures.h"
+
+QuickSpecBegin(SQRLDownloaderSpec)
+
+static const NSUInteger payloadLength = 4 * 1024 * 1024;
+
+__block NSData *payload;
+__block NSURL *serverURL;
+__block NSURL *requestLogURL;
+__block NSURL *resumeDataURL;
+__block NSURL *destinationURL;
+
+NSArray * (^requestLog)(void) = ^{
+	NSString *log = [NSString stringWithContentsOfURL:requestLogURL encoding:NSUTF8StringEncoding error:NULL];
+	return [[log componentsSeparatedByString:@"\n"] filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"length > 0"]];
+};
+
+SQRLDownloader * (^downloaderForPath)(NSString *) = ^(NSString *path) {
+	NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:path relativeToURL:serverURL]];
+	return [[SQRLDownloader alloc] initWithRequest:request resumeDataURL:resumeDataURL];
+};
+
+beforeEach(^{
+	NSMutableData *bytes = [NSMutableData dataWithLength:payloadLength];
+	arc4random_buf(bytes.mutableBytes, bytes.length);
+	payload = bytes;
+
+	NSURL *serveDirectoryURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:@"serve"];
+	expect(@([NSFileManager.defaultManager createDirectoryAtURL:serveDirectoryURL withIntermediateDirectories:YES attributes:nil error:NULL])).to(beTruthy());
+	expect(@([payload writeToURL:[serveDirectoryURL URLByAppendingPathComponent:@"payload.zip"] atomically:YES])).to(beTruthy());
+	expect(@([payload writeToURL:[serveDirectoryURL URLByAppendingPathComponent:@"other.zip"] atomically:YES])).to(beTruthy());
+
+	serverURL = [self startTestServerForDirectory:serveDirectoryURL requestLog:&requestLogURL];
+	resumeDataURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:@"download.resumedata"];
+	destinationURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:@"downloaded.zip"];
+});
+
+it(@"should stream the payload to the destination and report progress", ^{
+	SQRLDownloader *downloader = downloaderForPath(@"payload.zip");
+
+	NSMutableArray *progress = [NSMutableArray array];
+	[downloader.progress subscribeNext:^(SQRLDownloadProgress *value) {
+		@synchronized (progress) {
+			[progress addObject:value];
+		}
+	}];
+
+	NSError *error;
+	RACTuple *result = [[downloader downloadToURL:destinationURL] firstOrDefault:nil success:NULL error:&error];
+	expect(error).to(beNil());
+	expect(result.second).to(equal(destinationURL));
+	expect(@([(NSHTTPURLResponse *)result.first statusCode])).to(equal(@200));
+	expect([NSData dataWithContentsOfURL:destinationURL]).to(equal(payload));
+
+	SQRLDownloadProgress *last = progress.lastObject;
+	expect(@(last.bytesResumed)).to(equal(@0));
+	expect(@(last.bytesReceived)).to(equal(@(payloadLength)));
+	expect(@(last.bytesExpected)).to(equal(@(payloadLength)));
+	expect(@([NSFileManager.defaultManager fileExistsAtPath:resumeDataURL.path])).to(beFalsy());
+});
+
+it(@"should continue an interrupted transfer from where it stopped", ^{
+	NSError *error;
+	BOOL finished = [[downloaderForPath(@"payload.zip?drop=1048576") downloadToURL:destinationURL] waitUntilCompleted:&error];
+	expect(@(finished)).to(beFalsy());
+	expect(error.domain).to(equal(NSURLErrorDomain));
+	expect(@([NSFileManager.defaultManager fileExistsAtPath:resumeDataURL.path])).to(beTruthy());
+
+	SQRLDownloader *downloader = downloaderForPath(@"payload.zip?drop=1048576");
+	__block SQRLDownloadProgress *lastProgress;
+	[downloader.progress subscribeNext:^(SQRLDownloadProgress *value) {
+		lastProgress = value;
+	}];
+
+	error = nil;
+	RACTuple *result = [[downloader downloadToURL:destinationURL] firstOrDefault:nil success:NULL error:&error];
+	expect(error).to(beNil());
+	expect(@([(NSHTTPURLResponse *)result.first statusCode])).to(equal(@206));
+	expect([NSData dataWithContentsOfURL:destinationURL]).to(equal(payload));
+
+	expect(@(lastProgress.bytesResumed)).to(beGreaterThan(@0));
+	expect(@(lastProgress.bytesReceived)).to(equal(@(payloadLength)));
+	expect(requestLog().lastObject).to(beginWith([NSString stringWithFormat:@"GET /payload.zip Range=bytes=%lld-", lastProgress.bytesResumed]));
+	expect(@([NSFileManager.defaultManager fileExistsAtPath:resumeDataURL.path])).to(beFalsy());
+});
+
+it(@"should keep resume data when the download is disposed of", ^{
+	SQRLDownloader *downloader = downloaderForPath(@"payload.zip?slow=20");
+	RACDisposable *disposable = [[downloader downloadToURL:destinationURL] subscribeCompleted:^{}];
+
+	// Let some bytes arrive, then walk away as a caller losing interest would.
+	expect(@([[downloader.progress take:1] asynchronouslyWaitUntilCompleted:NULL])).to(beTruthy());
+	[disposable dispose];
+
+	expect(@([NSFileManager.defaultManager fileExistsAtPath:resumeDataURL.path])).toEventually(beTruthy());
+});
+
+it(@"should start over when the resume data belongs to another URL", ^{
+	[[downloaderForPath(@"payload.zip?drop=1048576") downloadToURL:destinationURL] waitUntilCompleted:NULL];
+	expect(@([NSFileManager.defaultManager fileExistsAtPath:resumeDataURL.path])).to(beTruthy());
+
+	NSError *error;
+	BOOL finished = [[downloaderForPath(@"other.zip") downloadToURL:destinationURL] waitUntilCompleted:&error];
+	expect(@(finished)).to(beTruthy());
+	expect(error).to(beNil());
+	expect([NSData dataWithContentsOfURL:destinationURL]).to(equal(payload));
+	expect(requestLog().lastObject).to(equal(@"GET /other.zip Range=- If-Range=-"));
+});
+
+it(@"should hand +cancelAllWritingResumeDataWithTimeout: the resume data of in-flight downloads", ^{
+	SQRLDownloader *downloader = downloaderForPath(@"payload.zip?slow=20");
+	[[downloader downloadToURL:destinationURL] subscribeCompleted:^{}];
+	expect(@([[downloader.progress take:1] asynchronouslyWaitUntilCompleted:NULL])).to(beTruthy());
+
+	[SQRLDownloader cancelAllWritingResumeDataWithTimeout:10];
+	expect(@([NSFileManager.defaultManager fileExistsAtPath:resumeDataURL.path])).to(beTruthy());
+});
+
+QuickSpecEnd

--- a/SquirrelTests/SQRLUpdateSpec.m
+++ b/SquirrelTests/SQRLUpdateSpec.m
@@ -43,6 +43,22 @@ it(@"should validate release name and notes", ^{
 	expect(update.releaseNotes).to(beNil());
 });
 
+it(@"should parse the package digest and size", ^{
+	SQRLUpdate *update = [MTLJSONAdapter modelOfClass:SQRLUpdate.class fromJSONDictionary:@{ @"url": @"http://example.com/update", @"sha256": @"ABCDEF", @"size": @1234 } error:NULL];
+	expect(update.packageDigest).to(equal(@"abcdef"));
+	expect(update.packageSize).to(equal(@1234));
+
+	update = [MTLJSONAdapter modelOfClass:SQRLUpdate.class fromJSONDictionary:@{ @"url": @"http://example.com/update" } error:NULL];
+	expect(update).notTo(beNil());
+	expect(update.packageDigest).to(beNil());
+	expect(update.packageSize).to(beNil());
+
+	NSError *error = nil;
+	update = [MTLJSONAdapter modelOfClass:SQRLUpdate.class fromJSONDictionary:@{ @"url": @"http://example.com/update", @"size": @"big" } error:&error];
+	expect(update).to(beNil());
+	expect(error).notTo(beNil());
+});
+
 it(@"should parse Central style dates", ^{
 	SQRLUpdate *update = [MTLJSONAdapter modelOfClass:SQRLUpdate.class fromJSONDictionary:@{ @"url": @"http://example.com/update", @"pub_date": @"Tue Sep 17 10:24:27 -0700 2013" } error:NULL];
 	expect(update.releaseDate).to(equal([NSDate dateWithTimeIntervalSince1970:1379438667]));

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -99,6 +99,15 @@ NSRunningApplication * (^launchWithEnvironment)(NSDictionary *) = ^(NSDictionary
 
 beforeEach(^{
 	JSONURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:@"update.json"];
+
+	// OHHTTPStubs registers a process-wide NSURLProtocol, which NSURLSession
+	// only consults for the shared session; hand it to the download sessions.
+	NSURLSessionConfiguration *configuration = NSURLSessionConfiguration.defaultSessionConfiguration;
+	configuration.protocolClasses = [@[ NSClassFromString(@"OHHTTPStubsProtocol") ] arrayByAddingObjectsFromArray:configuration.protocolClasses];
+	SQRLDownloader.sessionConfiguration = configuration;
+	[self addCleanupBlock:^{
+		SQRLDownloader.sessionConfiguration = nil;
+	}];
 });
 
 
@@ -641,6 +650,37 @@ describe(@"response handling", ^{
 		expect(error.domain).to(equal(SQRLUpdaterErrorDomain));
 		expect(@(error.code)).to(equal(@(SQRLUpdaterErrorInvalidServerResponse)));
 		expect(error.localizedDescription).to(contain(@"Update download failed"));
+	});
+
+	it(@"should reject a package that does not match the declared digest or size", ^{
+		NSData *package = [@"not the bytes you are looking for" dataUsingEncoding:NSUTF8StringEncoding];
+		__block NSDictionary *declared = nil;
+		OHHTTPStubs *stubsCheck = [OHHTTPStubs shouldStubRequestsPassingTest:^(NSURLRequest *request) {
+			return [request.URL isEqual:localRequest.URL];
+		} withStubResponse:^(NSURLRequest *request) {
+			NSMutableDictionary *body = [@{ @"url": @"http://fake/download.zip" } mutableCopy];
+			[body addEntriesFromDictionary:declared];
+			NSData *json = [NSJSONSerialization dataWithJSONObject:body options:0 error:NULL];
+			return [OHHTTPStubsResponse responseWithData:json statusCode:200 responseTime:0 headers:nil];
+		}];
+		OHHTTPStubs *stubsDownload = [OHHTTPStubs shouldStubRequestsPassingTest:^(NSURLRequest *request) {
+			return [request.URL.absoluteString isEqualToString:@"http://fake/download.zip"];
+		} withStubResponse:^(NSURLRequest *request) {
+			return [OHHTTPStubsResponse responseWithData:package statusCode:200 responseTime:0 headers:nil];
+		}];
+		[self addCleanupBlock:^{
+			[OHHTTPStubs removeRequestHandler:stubsCheck];
+			[OHHTTPStubs removeRequestHandler:stubsDownload];
+		}];
+
+		for (NSDictionary *mismatch in @[ @{ @"size": @(package.length + 1) }, @{ @"size": @(package.length), @"sha256": [@"" stringByPaddingToLength:64 withString:@"0" startingAtIndex:0] } ]) {
+			declared = mismatch;
+			NSError *error = nil;
+			BOOL result = [[updater.checkForUpdatesCommand execute:nil] asynchronouslyWaitUntilCompleted:&error];
+			expect(@(result)).to(beFalsy());
+			expect(error.domain).to(equal(SQRLUpdaterErrorDomain));
+			expect(@(error.code)).to(equal(@(SQRLUpdaterErrorInvalidUpdatePackage)));
+		}
 	});
 });
 

--- a/SquirrelTests/TestServer.py
+++ b/SquirrelTests/TestServer.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# A file server for the download specs: serves a directory with ETag,
+# Accept-Ranges and byte ranges, and can cut a transfer short.
+#
+#   TestServer.py <directory> <request-log>
+#
+# Prints "PORT <n>" once listening. Every request is appended to <request-log>
+# as "<METHOD> <path> Range=<header or -> If-Range=<header or ->".
+#
+#   GET /<file>?drop=<n>   the first request for <file> is closed after <n>
+#                          body bytes; later requests are served in full.
+#   GET /<file>?slow=<ms>  each 64 KiB of body is followed by a <ms> pause.
+
+import hashlib
+import http.server
+import os
+import socket
+import sys
+import time
+import urllib.parse
+
+root, request_log = sys.argv[1], sys.argv[2]
+dropped = set()
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format, *args):
+        sys.stderr.write("TestServer: " + (format % args) + "\n")
+
+    def do_GET(self):
+        url = urllib.parse.urlparse(self.path)
+        query = urllib.parse.parse_qs(url.query)
+        with open(request_log, "a") as log:
+            log.write("GET %s Range=%s If-Range=%s\n" % (url.path, self.headers.get("Range", "-"), self.headers.get("If-Range", "-")))
+
+        path = os.path.join(root, url.path.lstrip("/"))
+        if not os.path.isfile(path):
+            self.send_error(404)
+            return
+
+        size = os.path.getsize(path)
+        with open(path, "rb") as f:
+            etag = '"%s"' % hashlib.sha1(f.read()).hexdigest()
+
+        start = 0
+        if self.headers.get("Range") and self.headers.get("If-Range", etag) == etag:
+            start = int(self.headers["Range"].split("=")[1].split("-")[0])
+
+        self.send_response(206 if start else 200)
+        self.send_header("ETag", etag)
+        self.send_header("Accept-Ranges", "bytes")
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(size - start))
+        if start:
+            self.send_header("Content-Range", "bytes %d-%d/%d" % (start, size - 1, size))
+        self.end_headers()
+
+        limit = None
+        pause = int(query.get("slow", ["0"])[0]) / 1000.0
+        drop = int(query.get("drop", ["0"])[0])
+        if drop and url.path not in dropped:
+            dropped.add(url.path)
+            limit = drop
+
+        sent = 0
+        with open(path, "rb") as f:
+            f.seek(start)
+            while True:
+                chunk = f.read(64 * 1024)
+                if not chunk:
+                    break
+                if limit is not None and sent + len(chunk) >= limit:
+                    self.wfile.write(chunk[: limit - sent])
+                    self.wfile.flush()
+                    self.connection.shutdown(socket.SHUT_RDWR)
+                    self.close_connection = True
+                    return
+                try:
+                    self.wfile.write(chunk)
+                except (BrokenPipeError, ConnectionResetError):
+                    return
+                sent += len(chunk)
+                if pause:
+                    self.wfile.flush()
+                    time.sleep(pause)
+
+
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+sys.stdout.write("PORT %d\n" % server.server_address[1])
+sys.stdout.flush()
+server.serve_forever()


### PR DESCRIPTION
The update ZIP is fetched with a single `NSURLConnection sendAsynchronousRequest:` and held as one `NSData` before it is written out, so a large update is an equally large allocation in the host app, and any interruption (network change, sleep, quit) discards the whole transfer until the next check starts it again from zero. `NSURLConnection` has also been deprecated since 10.11.

This adds `SQRLDownloader`, a small wrapper around an `NSURLSession` download task, and moves `-downloadBundleForUpdate:intoDirectory:` onto it:

- the payload streams to a file in the update directory; nothing is buffered in memory
- when a transfer fails or is cancelled and the response carried a validator, the session's resume data is kept beside the `update.XXXXXXX` directories (`download.resumedata`), and the next check continues from that offset with a `Range` request instead of starting over; this holds after a relaunch too, since downloads still in flight at `NSApplicationWillTerminateNotification` hand over their resume data first
- resume data for a different URL, or that the session no longer accepts, is dropped and the download starts fresh, so the worst case is today's behaviour
- progress is published as `SQRLDownloadProgress` values on the new `SQRLUpdater.downloadProgress`
- `SQRLDownloader.sessionConfiguration` lets a host set network policy or protocol classes for the download sessions

Separately, an update may now declare `sha256` and `size` for its ZIP (`SQRLUpdate.packageDigest` / `packageSize`, both optional). A download that does not match is deleted before `ditto` runs and the check errors with `SQRLUpdaterErrorInvalidUpdatePackage`. Signature verification and installation are untouched.

Tests: `SQRLDownloaderSpec` runs against a small local HTTP server (`SquirrelTests/TestServer.py`, ranges + ETag, can cut a transfer short) and covers a full download with progress, resuming an interrupted transfer (asserts the `Range` request and a byte-identical result), keeping resume data on disposal and on `+cancelAllWritingResumeDataWithTimeout:`, and discarding resume data for another URL. `SQRLUpdaterSpec` gains the digest/size rejection case and `SQRLUpdateSpec` the parsing; the existing out-of-process update specs exercise the new path end to end over `file://`. 94 tests pass locally on macOS 26.5 / Xcode 26.5.