### PR TITLE
feat: apply a binary delta from the running version when the server offers one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: false
 
       - name: Init submodules
-        # Recursive init pulls 15 nested clones; only 8 are used by the
+        # Recursive init pulls 15 nested clones; only 9 are used by the
         # build (the rest are Mantle's / ReactiveObjC's / Quick's own
         # test deps).
         run: |
@@ -44,6 +44,7 @@ jobs:
             Carthage/Checkouts/Nimble \
             Carthage/Checkouts/Quick \
             Carthage/Checkouts/ReactiveObjC \
+            Carthage/Checkouts/Sparkle \
             Carthage/Checkouts/xcconfigs \
             External/OHHTTPStubs
           git -C Carthage/Checkouts/Mantle submodule update --init --depth 1 \

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "Carthage/Checkouts/ReactiveObjC"]
 	path = Carthage/Checkouts/ReactiveObjC
 	url = https://github.com/ReactiveCocoa/ReactiveObjC.git
+[submodule "Carthage/Checkouts/Sparkle"]
+	path = Carthage/Checkouts/Sparkle
+	url = https://github.com/sparkle-project/Sparkle.git

--- a/LICENSE
+++ b/LICENSE
@@ -18,3 +18,93 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+Squirrel.framework includes Sparkle's BinaryDelta implementation and the bsdiff
+sources Sparkle vendors (Carthage/Checkouts/Sparkle). Their notices follow.
+--------------------------------------------------------------------------------
+
+Copyright (c) 2006-2013 Andy Matuschak.
+Copyright (c) 2009-2013 Elgato Systems GmbH.
+Copyright (c) 2011-2014 Kornel Lesiński.
+Copyright (c) 2015-2017 Mayur Pawashe.
+Copyright (c) 2014 C.W. Betts.
+Copyright (c) 2014 Petroules Corporation.
+Copyright (c) 2014 Big Nerd Ranch.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+=================
+EXTERNAL LICENSES
+=================
+
+bspatch.c and bsdiff.c, from bsdiff 4.3 <http://www.daemonology.net/bsdiff/>:
+
+Copyright 2003-2005 Colin Percival
+All rights reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions 
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+--
+
+sais.c and sais.h, from sais-lite (2010/08/07) <https://sites.google.com/site/yuta256/sais>:
+
+The sais-lite copyright is as follows:
+
+Copyright (c) 2008-2010 Yuta Mori All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,13 @@ to the update request provided:
 	"notes": "Theses are some release notes innit",
 	"pub_date": "2013-09-18T12:29:53+01:00",
 	"sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
-	"size": 104857600
+	"size": 104857600,
+	"delta": {
+		"from_version": "412",
+		"url": "https://mycompany.example.com/myapp/releases/412-to-myrelease.delta",
+		"sha256": "60303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c752",
+		"size": 7340032
+	}
 }
 ```
 
@@ -193,6 +199,19 @@ path. Downloads run in their own `NSURLSession`, so an `NSURLProtocol`
 registered with `+registerClass:` sees the update check but not the download;
 set `SQRLDownloader.sessionConfiguration` (with its `protocolClasses`) to
 intercept both.
+
+"delta", if present, offers a binary patch from one earlier build to this
+release; it needs all four keys ("sha256" as 64 hex digits, "size" positive)
+and is logged and ignored otherwise. When "from_version" equals the
+running application's `CFBundleVersion`, Squirrel downloads the patch instead
+of the ZIP, checks its "size" and "sha256", applies it to a copy of the running
+application, and puts the result through the same code signing verification as
+an unpacked ZIP. If any of that fails, or "from_version" is anything else, it
+downloads the ZIP from "url" in the same check, so a server can always include
+the one delta it has for the version that asked. Patches are
+[Sparkle](https://sparkle-project.org) BinaryDelta files (format 3 or 4), made
+with Sparkle's `BinaryDelta create <old.app> <new.app> <patch>` from the exact
+signed bundles that were shipped.
 
 ## Update File JSON Format
 
@@ -250,6 +269,7 @@ file); a single entry is fine.
 | `updateTo.version` | — | Echoed into the `update-downloaded` event; conventionally the same as the outer `version`. |
 | `updateTo.name` / `notes` / `pub_date` | — | Surfaced to your app for display. `pub_date` must be ISO 8601 if present. |
 | `updateTo.sha256` / `size` | — | Digest (hex) and byte size of the `.zip`; a download that does not match is rejected. |
+| `updateTo.delta` | — | Optional `{from_version, url, sha256, size}` binary patch from one earlier `CFBundleVersion`; tried first when it matches the running app, with the `.zip` as fallback. |
 
 Point the updater directly at this file's URL — there's no required filename.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ repository (under `Carthage/Checkouts/`, a directory name kept from when they
 were fetched with Carthage); `git submodule update --init` or `script/bootstrap`
 checks them out.
 
+Binary delta support compiles Sparkle's BinaryDelta sources and the bsdiff it
+vendors straight out of a third submodule, `Carthage/Checkouts/Sparkle`, pinned
+to a Sparkle release tag (currently 2.9.5); nothing of Sparkle is linked as a
+framework and applications need not ship it. To move the pin, check out the new
+tag in the submodule, build, run the tests, and commit the submodule change; the
+files involved are listed under the SparkleDelta group in the Xcode project.
+
 If your application is already using ReactiveObjC, ensure it is using the same
 version as Squirrel.
 
@@ -210,11 +217,22 @@ running application's `CFBundleVersion`, Squirrel downloads the patch instead
 of the ZIP, checks its "size" and "sha256", applies it to a copy of the running
 application, and puts the result through the same code signing verification as
 an unpacked ZIP. If any of that fails, or "from_version" is anything else, it
-downloads the ZIP from "url" in the same check, so a server can always include
-the one delta it has for the version that asked. Patches are
-[Sparkle](https://sparkle-project.org) BinaryDelta files (format 3 or 4), made
-with Sparkle's `BinaryDelta create <old.app> <new.app> <patch>` from the exact
-signed bundles that were shipped.
+downloads the ZIP from "url" in the same check (its `downloadProgress` starting
+again from zero), so a server can always include the one delta it has for the
+version that asked. A delta that has been applied and staged is not fetched
+again by later checks in the same process.
+
+Patches are [Sparkle](https://sparkle-project.org) BinaryDelta files (format 3
+or 4, any `--compression` except `bzip2`), made with Sparkle's
+`BinaryDelta create <old.app> <new.app> <patch>`. A patch only applies to a
+byte-identical copy of `<old.app>`, file modes included, and ShipIt clears the
+group and other write bits of everything it installs; strip them from the app
+before signing it (`chmod -R go-w MyApp.app`) so the shipped bundle, the
+installed bundle and the trees the patch was made from all agree, otherwise
+the patch applies once to a fresh install and never again. Files the patch adds
+or rewrites are created with decomposed (NFD) names, so a non-ASCII file name
+outside an archive such as `app.asar` can fail code signing verification and
+cost a fallback to the ZIP. "from_version" may be a JSON string or number.
 
 ## Update File JSON Format
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ an unpacked ZIP. If any of that fails, or "from_version" is anything else, it
 downloads the ZIP from "url" in the same check (its `downloadProgress` starting
 again from zero), so a server can always include the one delta it has for the
 version that asked. A delta that has been applied and staged is not fetched
-again by later checks in the same process.
+again by later checks in the same process, and neither is one that downloaded
+intact but would not apply or verify.
 
 Patches are [Sparkle](https://sparkle-project.org) BinaryDelta files (format 3
 or 4, any `--compression` except `bzip2`), made with Sparkle's

--- a/Squirrel.xcodeproj/project.pbxproj
+++ b/Squirrel.xcodeproj/project.pbxproj
@@ -29,6 +29,9 @@
 		D000219717BAD34D0050109A /* TestApplication.app.zip in Resources */ = {isa = PBXBuildFile; fileRef = D000219617BAD34D0050109A /* TestApplication.app.zip */; };
 		D000219917BAD35C0050109A /* SQRLZipArchiverSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D000219817BAD35C0050109A /* SQRLZipArchiverSpec.m */; };
 		D0F0A00126500005000D0AD1 /* SQRLDownloaderSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A00126500006000D0AD1 /* SQRLDownloaderSpec.m */; };
+		D0F0A00426500003000D0AD1 /* SUBinaryDeltaCreate.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A00426500002000D0AD1 /* SUBinaryDeltaCreate.m */; settings = {COMPILER_FLAGS = "-w $(SPARKLE_DELTA_CFLAGS)"; }; };
+		D0F0A00426500005000D0AD1 /* bsdiff.c in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A00426500004000D0AD1 /* bsdiff.c */; settings = {COMPILER_FLAGS = "-w $(SPARKLE_DELTA_CFLAGS)"; }; };
+		D0F0A00426500007000D0AD1 /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A00426500006000D0AD1 /* sais.c */; settings = {COMPILER_FLAGS = "-w $(SPARKLE_DELTA_CFLAGS)"; }; };
 		D0F0A00126500007000D0AD1 /* TestServer.py in Resources */ = {isa = PBXBuildFile; fileRef = D0F0A00126500008000D0AD1 /* TestServer.py */; };
 		D00F5B8B17E82D15009A4818 /* NSProcessInfo+SQRLVersionExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D00F5B8917E82D15009A4818 /* NSProcessInfo+SQRLVersionExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D00F5B8C17E82D15009A4818 /* NSProcessInfo+SQRLVersionExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D00F5B8A17E82D15009A4818 /* NSProcessInfo+SQRLVersionExtensions.m */; };
@@ -87,7 +90,15 @@
 		D0C22C4D179CC15100158214 /* SQRLUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C22C4B179CC15100158214 /* SQRLUpdater.m */; };
 		D0F0A00126500001000D0AD1 /* SQRLDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = D0F0A00126500003000D0AD1 /* SQRLDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0F0A00126500002000D0AD1 /* SQRLDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A00126500004000D0AD1 /* SQRLDownloader.m */; };
-		D0C22C50179CC18C00158214 /* SQRLUpdaterSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C22C4F179CC18C00158214 /* SQRLUpdaterSpec.m */; };
+		D0F0A00326500003000D0AD1 /* SQRLUpdateDelta.h in Headers */ = {isa = PBXBuildFile; fileRef = D0F0A00326500001000D0AD1 /* SQRLUpdateDelta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D0F0A00326500004000D0AD1 /* SQRLUpdateDelta.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A00326500002000D0AD1 /* SQRLUpdateDelta.m */; };
+		D0F0A00226500003000D0AD1 /* SUBinaryDeltaApply.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A00226500002000D0AD1 /* SUBinaryDeltaApply.m */; settings = {COMPILER_FLAGS = "-w $(SPARKLE_DELTA_CFLAGS)"; }; };
+		D0F0A00226500006000D0AD1 /* SUBinaryDeltaCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A00226500005000D0AD1 /* SUBinaryDeltaCommon.m */; settings = {COMPILER_FLAGS = "-w $(SPARKLE_DELTA_CFLAGS)"; }; };
+		D0F0A00226500009000D0AD1 /* SPUDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A00226500008000D0AD1 /* SPUDeltaArchive.m */; settings = {COMPILER_FLAGS = "-w $(SPARKLE_DELTA_CFLAGS)"; }; };
+		D0F0A0022650000E000D0AD1 /* SPUSparkleDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A0022650000D000D0AD1 /* SPUSparkleDeltaArchive.m */; settings = {COMPILER_FLAGS = "-w $(SPARKLE_DELTA_CFLAGS)"; }; };
+		D0F0A00226500011000D0AD1 /* bspatch.c in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A00226500010000D0AD1 /* bspatch.c */; settings = {COMPILER_FLAGS = "-w $(SPARKLE_DELTA_CFLAGS)"; }; };
+		D0F0A00226500014000D0AD1 /* bscommon.c in Sources */ = {isa = PBXBuildFile; fileRef = D0F0A00226500013000D0AD1 /* bscommon.c */; settings = {COMPILER_FLAGS = "-w $(SPARKLE_DELTA_CFLAGS)"; }; };
+		D0C22C50179CC18C00158214 /* SQRLUpdaterSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C22C4F179CC18C00158214 /* SQRLUpdaterSpec.m */; settings = {COMPILER_FLAGS = "$(SPARKLE_DELTA_CFLAGS)"; }; };
 		D0C22C52179CC23900158214 /* Squirrel.h in Headers */ = {isa = PBXBuildFile; fileRef = D0C22BE7179CC00E00158214 /* Squirrel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0D2B6261804E903000EA901 /* SQRLDirectoryManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D0D2B6241804E903000EA901 /* SQRLDirectoryManager.m */; };
 		D0D2B6271804E903000EA901 /* SQRLDirectoryManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D0D2B6241804E903000EA901 /* SQRLDirectoryManager.m */; };
@@ -239,6 +250,29 @@
 		D000219617BAD34D0050109A /* TestApplication.app.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = TestApplication.app.zip; sourceTree = "<group>"; };
 		D000219817BAD35C0050109A /* SQRLZipArchiverSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLZipArchiverSpec.m; sourceTree = "<group>"; };
 		D0F0A00126500006000D0AD1 /* SQRLDownloaderSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLDownloaderSpec.m; sourceTree = "<group>"; };
+		D0F0A00426500001000D0AD1 /* SUBinaryDeltaCreate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SUBinaryDeltaCreate.h; path = Autoupdate/SUBinaryDeltaCreate.h; sourceTree = "<group>"; };
+		D0F0A00426500002000D0AD1 /* SUBinaryDeltaCreate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SUBinaryDeltaCreate.m; path = Autoupdate/SUBinaryDeltaCreate.m; sourceTree = "<group>"; };
+		D0F0A00426500004000D0AD1 /* bsdiff.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bsdiff.c; path = Vendor/bsdiff/bsdiff.c; sourceTree = "<group>"; };
+		D0F0A00426500006000D0AD1 /* sais.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sais.c; path = Vendor/bsdiff/sais.c; sourceTree = "<group>"; };
+		D0F0A00426500008000D0AD1 /* sais.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sais.h; path = Vendor/bsdiff/sais.h; sourceTree = "<group>"; };
+		D0F0A00326500001000D0AD1 /* SQRLUpdateDelta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQRLUpdateDelta.h; sourceTree = "<group>"; };
+		D0F0A00326500002000D0AD1 /* SQRLUpdateDelta.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQRLUpdateDelta.m; sourceTree = "<group>"; };
+		D0F0A00226500001000D0AD1 /* SUBinaryDeltaApply.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SUBinaryDeltaApply.h; path = Autoupdate/SUBinaryDeltaApply.h; sourceTree = "<group>"; };
+		D0F0A00226500002000D0AD1 /* SUBinaryDeltaApply.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SUBinaryDeltaApply.m; path = Autoupdate/SUBinaryDeltaApply.m; sourceTree = "<group>"; };
+		D0F0A00226500004000D0AD1 /* SUBinaryDeltaCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SUBinaryDeltaCommon.h; path = Autoupdate/SUBinaryDeltaCommon.h; sourceTree = "<group>"; };
+		D0F0A00226500005000D0AD1 /* SUBinaryDeltaCommon.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SUBinaryDeltaCommon.m; path = Autoupdate/SUBinaryDeltaCommon.m; sourceTree = "<group>"; };
+		D0F0A00226500007000D0AD1 /* SPUDeltaArchive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPUDeltaArchive.h; path = Autoupdate/SPUDeltaArchive.h; sourceTree = "<group>"; };
+		D0F0A00226500008000D0AD1 /* SPUDeltaArchive.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPUDeltaArchive.m; path = Autoupdate/SPUDeltaArchive.m; sourceTree = "<group>"; };
+		D0F0A0022650000A000D0AD1 /* SPUDeltaArchiveProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPUDeltaArchiveProtocol.h; path = Autoupdate/SPUDeltaArchiveProtocol.h; sourceTree = "<group>"; };
+		D0F0A0022650000B000D0AD1 /* SPUDeltaCompressionMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPUDeltaCompressionMode.h; path = Autoupdate/SPUDeltaCompressionMode.h; sourceTree = "<group>"; };
+		D0F0A0022650000C000D0AD1 /* SPUSparkleDeltaArchive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPUSparkleDeltaArchive.h; path = Autoupdate/SPUSparkleDeltaArchive.h; sourceTree = "<group>"; };
+		D0F0A0022650000D000D0AD1 /* SPUSparkleDeltaArchive.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPUSparkleDeltaArchive.m; path = Autoupdate/SPUSparkleDeltaArchive.m; sourceTree = "<group>"; };
+		D0F0A0022650000F000D0AD1 /* bspatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bspatch.h; path = Vendor/bsdiff/bspatch.h; sourceTree = "<group>"; };
+		D0F0A00226500010000D0AD1 /* bspatch.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bspatch.c; path = Vendor/bsdiff/bspatch.c; sourceTree = "<group>"; };
+		D0F0A00226500012000D0AD1 /* bscommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bscommon.h; path = Vendor/bsdiff/bscommon.h; sourceTree = "<group>"; };
+		D0F0A00226500013000D0AD1 /* bscommon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bscommon.c; path = Vendor/bsdiff/bscommon.c; sourceTree = "<group>"; };
+		D0F0A00226500015000D0AD1 /* AppKitPrevention.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppKitPrevention.h; path = Sparkle/AppKitPrevention.h; sourceTree = "<group>"; };
+		D0F0A00226500030000D0AD1 /* SparkleDeltaConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SparkleDeltaConfig.h; path = SparkleDelta/SparkleDeltaConfig.h; sourceTree = "<group>"; };
 		D0F0A00126500008000D0AD1 /* TestServer.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = TestServer.py; sourceTree = "<group>"; };
 		D00F5B8917E82D15009A4818 /* NSProcessInfo+SQRLVersionExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSProcessInfo+SQRLVersionExtensions.h"; sourceTree = "<group>"; };
 		D00F5B8A17E82D15009A4818 /* NSProcessInfo+SQRLVersionExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSProcessInfo+SQRLVersionExtensions.m"; sourceTree = "<group>"; };
@@ -530,6 +564,8 @@
 				D0C22C4A179CC15100158214 /* SQRLUpdater.h */,
 				D0C22C4B179CC15100158214 /* SQRLUpdater.m */,
 				D0F0A00126500003000D0AD1 /* SQRLDownloader.h */,
+				D0F0A00326500001000D0AD1 /* SQRLUpdateDelta.h */,
+				D0F0A00326500002000D0AD1 /* SQRLUpdateDelta.m */,
 				D0F0A00126500004000D0AD1 /* SQRLDownloader.m */,
 				53AACF4917E9CA0500B41027 /* SQRLUpdate.h */,
 				53AACF4A17E9CA0500B41027 /* SQRLUpdate.m */,
@@ -588,11 +624,48 @@
 			name = "Static Dependencies";
 			sourceTree = "<group>";
 		};
+		D0F0A00226500016000D0AD1 /* SparkleDelta */ = {
+			isa = PBXGroup;
+			children = (
+				D0F0A00226500001000D0AD1 /* SUBinaryDeltaApply.h */,
+				D0F0A00226500002000D0AD1 /* SUBinaryDeltaApply.m */,
+				D0F0A00226500004000D0AD1 /* SUBinaryDeltaCommon.h */,
+				D0F0A00226500005000D0AD1 /* SUBinaryDeltaCommon.m */,
+				D0F0A00226500007000D0AD1 /* SPUDeltaArchive.h */,
+				D0F0A00226500008000D0AD1 /* SPUDeltaArchive.m */,
+				D0F0A0022650000A000D0AD1 /* SPUDeltaArchiveProtocol.h */,
+				D0F0A0022650000B000D0AD1 /* SPUDeltaCompressionMode.h */,
+				D0F0A0022650000C000D0AD1 /* SPUSparkleDeltaArchive.h */,
+				D0F0A0022650000D000D0AD1 /* SPUSparkleDeltaArchive.m */,
+				D0F0A0022650000F000D0AD1 /* bspatch.h */,
+				D0F0A00226500010000D0AD1 /* bspatch.c */,
+				D0F0A00226500012000D0AD1 /* bscommon.h */,
+				D0F0A00226500013000D0AD1 /* bscommon.c */,
+				D0F0A00226500015000D0AD1 /* AppKitPrevention.h */,
+			);
+			name = Sparkle;
+			path = Carthage/Checkouts/Sparkle;
+			sourceTree = "<group>";
+		};
+		D0F0A00426500009000D0AD1 /* SparkleDeltaCreate */ = {
+			isa = PBXGroup;
+			children = (
+				D0F0A00426500001000D0AD1 /* SUBinaryDeltaCreate.h */,
+				D0F0A00426500002000D0AD1 /* SUBinaryDeltaCreate.m */,
+				D0F0A00426500004000D0AD1 /* bsdiff.c */,
+				D0F0A00426500006000D0AD1 /* sais.c */,
+				D0F0A00426500008000D0AD1 /* sais.h */,
+			);
+			name = SparkleDeltaCreate;
+			path = ../Carthage/Checkouts/Sparkle;
+			sourceTree = "<group>";
+		};
 		D0C22BCD179CC00E00158214 = {
 			isa = PBXGroup;
 			children = (
 				D0EDBE9F17B0C6930058BC3C /* Shared */,
 				D0C22BE0179CC00E00158214 /* Squirrel */,
+				D0F0A00226500016000D0AD1 /* SparkleDelta */,
 				D014AC0317B97885007D79D0 /* ShipIt */,
 				D0C22BF6179CC00E00158214 /* SquirrelTests */,
 				D08D4E0E17B451500012B22D /* TestApplication */,
@@ -640,6 +713,7 @@
 			isa = PBXGroup;
 			children = (
 				D0C22BE7179CC00E00158214 /* Squirrel.h */,
+				D0F0A00226500030000D0AD1 /* SparkleDeltaConfig.h */,
 				D00F5B8217E82CFB009A4818 /* Extensions */,
 				D0C22C49179CC14400158214 /* Classes */,
 				D0C22BE1179CC00E00158214 /* Supporting Files */,
@@ -769,6 +843,7 @@
 				5395C0E217E9D013001648E8 /* SQRLUpdateSpec.m */,
 				D000219817BAD35C0050109A /* SQRLZipArchiverSpec.m */,
 				D0F0A00126500006000D0AD1 /* SQRLDownloaderSpec.m */,
+				D0F0A00426500009000D0AD1 /* SparkleDeltaCreate */,
 			);
 			name = Specs;
 			sourceTree = "<group>";
@@ -798,6 +873,7 @@
 				D0964B3C17F2E20B00D88BF7 /* NSBundle+SQRLVersionExtensions.h in Headers */,
 				D0C22C4C179CC15100158214 /* SQRLUpdater.h in Headers */,
 				D0F0A00126500001000D0AD1 /* SQRLDownloader.h in Headers */,
+				D0F0A00326500003000D0AD1 /* SQRLUpdateDelta.h in Headers */,
 				D0C22C52179CC23900158214 /* Squirrel.h in Headers */,
 				D0964B3817F2E01500D88BF7 /* SQRLDownloadedUpdate.h in Headers */,
 				53AACF4B17E9CA0500B41027 /* SQRLUpdate.h in Headers */,
@@ -1053,6 +1129,13 @@
 				D000218F17BACEFF0050109A /* SQRLZipArchiver.m in Sources */,
 				D0C22C4D179CC15100158214 /* SQRLUpdater.m in Sources */,
 				D0F0A00126500002000D0AD1 /* SQRLDownloader.m in Sources */,
+				D0F0A00326500004000D0AD1 /* SQRLUpdateDelta.m in Sources */,
+				D0F0A00226500003000D0AD1 /* SUBinaryDeltaApply.m in Sources */,
+				D0F0A00226500006000D0AD1 /* SUBinaryDeltaCommon.m in Sources */,
+				D0F0A00226500009000D0AD1 /* SPUDeltaArchive.m in Sources */,
+				D0F0A0022650000E000D0AD1 /* SPUSparkleDeltaArchive.m in Sources */,
+				D0F0A00226500011000D0AD1 /* bspatch.c in Sources */,
+				D0F0A00226500014000D0AD1 /* bscommon.c in Sources */,
 				D0EDBE9D17B0C68E0058BC3C /* NSError+SQRLVerbosityExtensions.m in Sources */,
 				53AACF4C17E9CA0500B41027 /* SQRLUpdate.m in Sources */,
 				5397A5CF187D92810014A477 /* SQRLShipItRequest.m in Sources */,
@@ -1069,6 +1152,9 @@
 				5395C0E317E9D013001648E8 /* SQRLUpdateSpec.m in Sources */,
 				D000219917BAD35C0050109A /* SQRLZipArchiverSpec.m in Sources */,
 				D0F0A00126500005000D0AD1 /* SQRLDownloaderSpec.m in Sources */,
+				D0F0A00426500003000D0AD1 /* SUBinaryDeltaCreate.m in Sources */,
+				D0F0A00426500005000D0AD1 /* bsdiff.c in Sources */,
+				D0F0A00426500007000D0AD1 /* sais.c in Sources */,
 				D043F77E17FF43640012F996 /* SQRLTerminationListener.m in Sources */,
 				D09D244117B595470001FAF8 /* SQRLInstallerSpec.m in Sources */,
 				D0C22C50179CC18C00158214 /* SQRLUpdaterSpec.m in Sources */,
@@ -1328,6 +1414,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0C22C0B179CC02E00158214 /* Debug.xcconfig */;
 			buildSettings = {
+				SPARKLE_DELTA_CFLAGS = "-include $(SRCROOT)/Squirrel/SparkleDelta/SparkleDeltaConfig.h -I$(SRCROOT)/Carthage/Checkouts/Sparkle/Autoupdate -I$(SRCROOT)/Carthage/Checkouts/Sparkle/Vendor/bsdiff -I$(SRCROOT)/Carthage/Checkouts/Sparkle/Sparkle";
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				ENABLE_TESTABILITY = YES;
@@ -1346,6 +1433,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0C22C0D179CC02E00158214 /* Release.xcconfig */;
 			buildSettings = {
+				SPARKLE_DELTA_CFLAGS = "-include $(SRCROOT)/Squirrel/SparkleDelta/SparkleDeltaConfig.h -I$(SRCROOT)/Carthage/Checkouts/Sparkle/Autoupdate -I$(SRCROOT)/Carthage/Checkouts/Sparkle/Vendor/bsdiff -I$(SRCROOT)/Carthage/Checkouts/Sparkle/Sparkle";
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING = YES;
@@ -1364,6 +1452,12 @@
 			baseConfigurationReference = D0C22C1A179CC02E00158214 /* Mac-Framework.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lbz2",
+					"-lz",
+					"-lcompression",
+				);
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1383,6 +1477,12 @@
 			baseConfigurationReference = D0C22C1A179CC02E00158214 /* Mac-Framework.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lbz2",
+					"-lz",
+					"-lcompression",
+				);
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1441,6 +1541,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0C22C0C179CC02E00158214 /* Profile.xcconfig */;
 			buildSettings = {
+				SPARKLE_DELTA_CFLAGS = "-include $(SRCROOT)/Squirrel/SparkleDelta/SparkleDeltaConfig.h -I$(SRCROOT)/Carthage/Checkouts/Sparkle/Autoupdate -I$(SRCROOT)/Carthage/Checkouts/Sparkle/Vendor/bsdiff -I$(SRCROOT)/Carthage/Checkouts/Sparkle/Sparkle";
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING = YES;
@@ -1459,6 +1560,12 @@
 			baseConfigurationReference = D0C22C1A179CC02E00158214 /* Mac-Framework.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lbz2",
+					"-lz",
+					"-lcompression",
+				);
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1497,6 +1604,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0C22C0E179CC02E00158214 /* Test.xcconfig */;
 			buildSettings = {
+				SPARKLE_DELTA_CFLAGS = "-include $(SRCROOT)/Squirrel/SparkleDelta/SparkleDeltaConfig.h -I$(SRCROOT)/Carthage/Checkouts/Sparkle/Autoupdate -I$(SRCROOT)/Carthage/Checkouts/Sparkle/Vendor/bsdiff -I$(SRCROOT)/Carthage/Checkouts/Sparkle/Sparkle";
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING = YES;
@@ -1514,6 +1622,12 @@
 			baseConfigurationReference = D0C22C1A179CC02E00158214 /* Mac-Framework.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lbz2",
+					"-lz",
+					"-lcompression",
+				);
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/Squirrel/SQRLUpdate.h
+++ b/Squirrel/SQRLUpdate.h
@@ -9,6 +9,8 @@
 #import <Foundation/Foundation.h>
 #import <Mantle/Mantle.h>
 
+@class SQRLUpdateDelta;
+
 // An update parsed from a response to the `SQRLUpdater.updateRequest`.
 //
 // This can be subclassed, and `SQRLUpdater.updateClass` set, to preserve
@@ -37,5 +39,10 @@
 // number (anything else is logged and ignored). A downloaded package of any
 // other size is rejected before it is opened.
 @property (readonly, copy, nonatomic) NSNumber *packageSize;
+
+// A binary delta from the running version to this update, if the server has
+// one. When present and applicable it is tried first; any failure to download,
+// verify, apply or code-sign-check it falls back to `updateURL`.
+@property (readonly, copy, nonatomic) SQRLUpdateDelta *delta;
 
 @end

--- a/Squirrel/SQRLUpdate.m
+++ b/Squirrel/SQRLUpdate.m
@@ -7,6 +7,7 @@
 //
 
 #import "SQRLUpdate.h"
+#import "SQRLUpdateDelta.h"
 #import <ReactiveObjC/ReactiveObjC.h>
 
 NSString * const SQRLUpdateJSONURLKey = @"url";
@@ -67,6 +68,7 @@ NSString * const SQRLUpdateJSONPublicationDateKey = @"pub_date";
 		@keypath(SQRLUpdate.new, updateURL): @"url",
 		@keypath(SQRLUpdate.new, packageDigest): @"sha256",
 		@keypath(SQRLUpdate.new, packageSize): @"size",
+		@keypath(SQRLUpdate.new, delta): @"delta",
 	};
 }
 
@@ -93,6 +95,19 @@ NSString * const SQRLUpdateJSONPublicationDateKey = @"pub_date";
 
 		NSLog(@"Ignoring update \"size\" that is not a positive number: %@", size);
 		return nil;
+	}];
+}
+
+// A `delta` that does not parse is logged and dropped: offering one must
+// never cost the update it rides on.
++ (NSValueTransformer *)deltaJSONTransformer {
+	return [MTLValueTransformer transformerUsingForwardBlock:^ id (id JSON, BOOL *success, NSError **error) {
+		NSError *deltaError = nil;
+		SQRLUpdateDelta *delta = [JSON isKindOfClass:NSDictionary.class] ? [MTLJSONAdapter modelOfClass:SQRLUpdateDelta.class fromJSONDictionary:JSON error:&deltaError] : nil;
+		if (delta == nil) NSLog(@"Ignoring update \"delta\" that cannot be used: %@ (%@)", JSON, deltaError.localizedRecoverySuggestion ?: deltaError);
+		return delta;
+	} reverseBlock:^ id (SQRLUpdateDelta *delta, BOOL *success, NSError **error) {
+		return delta == nil ? nil : [MTLJSONAdapter JSONDictionaryFromModel:delta error:error];
 	}];
 }
 

--- a/Squirrel/SQRLUpdate.m
+++ b/Squirrel/SQRLUpdate.m
@@ -102,6 +102,13 @@ NSString * const SQRLUpdateJSONPublicationDateKey = @"pub_date";
 // never cost the update it rides on.
 + (NSValueTransformer *)deltaJSONTransformer {
 	return [MTLValueTransformer transformerUsingForwardBlock:^ id (id JSON, BOOL *success, NSError **error) {
+		// CFBundleVersion is often a bare build number; accept it as one.
+		if ([JSON isKindOfClass:NSDictionary.class] && [JSON[@"from_version"] isKindOfClass:NSNumber.class]) {
+			NSMutableDictionary *stringified = [JSON mutableCopy];
+			stringified[@"from_version"] = [JSON[@"from_version"] stringValue];
+			JSON = stringified;
+		}
+
 		NSError *deltaError = nil;
 		SQRLUpdateDelta *delta = [JSON isKindOfClass:NSDictionary.class] ? [MTLJSONAdapter modelOfClass:SQRLUpdateDelta.class fromJSONDictionary:JSON error:&deltaError] : nil;
 		if (delta == nil) NSLog(@"Ignoring update \"delta\" that cannot be used: %@ (%@)", JSON, deltaError.localizedRecoverySuggestion ?: deltaError);

--- a/Squirrel/SQRLUpdateDelta.h
+++ b/Squirrel/SQRLUpdateDelta.h
@@ -1,0 +1,31 @@
+//
+//  SQRLUpdateDelta.h
+//  Squirrel
+//
+
+#import <Foundation/Foundation.h>
+#import <Mantle/Mantle.h>
+
+// A binary delta that turns one specific earlier version of the application
+// into the update it accompanies (see SQRLUpdate.delta).
+//
+// The patch is a Sparkle BinaryDelta container (major version 3 or 4). It is
+// only ever applied to the running application when `fromVersion` names its
+// CFBundleVersion, and the result must pass the same code signing check as a
+// fully downloaded update; otherwise the full update is downloaded instead.
+@interface SQRLUpdateDelta : MTLModel <MTLJSONSerializing>
+
+// The CFBundleVersion this delta applies to. Required.
+@property (readonly, copy, nonatomic) NSString *fromVersion;
+
+// Where the delta can be downloaded from. Required.
+@property (readonly, copy, nonatomic) NSURL *deltaURL;
+
+// The SHA-256 digest of the delta file, as lowercase hex. Required: a delta
+// that does not match is never opened.
+@property (readonly, copy, nonatomic) NSString *digest;
+
+// The size of the delta file in bytes. Required.
+@property (readonly, copy, nonatomic) NSNumber *size;
+
+@end

--- a/Squirrel/SQRLUpdateDelta.m
+++ b/Squirrel/SQRLUpdateDelta.m
@@ -19,7 +19,7 @@
 	if (self.fromVersion.length == 0) missing = @"from_version";
 	else if (self.deltaURL.scheme == nil || self.deltaURL.path == nil) missing = @"url";
 	else if (self.digest.length != 64 || [self.digest rangeOfCharacterFromSet:notHex].location != NSNotFound) missing = @"sha256";
-	else if (self.size.longLongValue <= 0) missing = @"size";
+	else if (![self.size isKindOfClass:NSNumber.class] || CFGetTypeID((__bridge CFTypeRef)self.size) == CFBooleanGetTypeID() || CFNumberIsFloatType((__bridge CFNumberRef)self.size) || self.size.longLongValue <= 0) missing = @"size";
 
 	if (missing != nil) {
 		if (error != NULL) {

--- a/Squirrel/SQRLUpdateDelta.m
+++ b/Squirrel/SQRLUpdateDelta.m
@@ -1,0 +1,58 @@
+//
+//  SQRLUpdateDelta.m
+//  Squirrel
+//
+
+#import "SQRLUpdateDelta.h"
+#import <ReactiveObjC/EXTKeyPathCoding.h>
+
+@implementation SQRLUpdateDelta
+
+#pragma mark Lifecycle
+
+- (id)initWithDictionary:(NSDictionary *)dictionary error:(NSError **)error {
+	self = [super initWithDictionary:dictionary error:error];
+	if (self == nil) return nil;
+
+	NSCharacterSet *notHex = [NSCharacterSet characterSetWithCharactersInString:@"0123456789abcdef"].invertedSet;
+	NSString *missing = nil;
+	if (self.fromVersion.length == 0) missing = @"from_version";
+	else if (self.deltaURL.scheme == nil || self.deltaURL.path == nil) missing = @"url";
+	else if (self.digest.length != 64 || [self.digest rangeOfCharacterFromSet:notHex].location != NSNotFound) missing = @"sha256";
+	else if (self.size.longLongValue <= 0) missing = @"size";
+
+	if (missing != nil) {
+		if (error != NULL) {
+			*error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSKeyValueValidationError userInfo:@{
+				NSLocalizedDescriptionKey: NSLocalizedString(@"Validation failed", nil),
+				NSLocalizedRecoverySuggestionErrorKey: [NSString stringWithFormat:NSLocalizedString(@"A delta update needs a valid \"%@\".", nil), missing],
+			}];
+		}
+		return nil;
+	}
+
+	return self;
+}
+
+#pragma mark MTLJSONSerializing
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+		@keypath(SQRLUpdateDelta.new, fromVersion): @"from_version",
+		@keypath(SQRLUpdateDelta.new, deltaURL): @"url",
+		@keypath(SQRLUpdateDelta.new, digest): @"sha256",
+		@keypath(SQRLUpdateDelta.new, size): @"size",
+	};
+}
+
++ (NSValueTransformer *)deltaURLJSONTransformer {
+	return [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
+}
+
++ (NSValueTransformer *)digestJSONTransformer {
+	return [MTLValueTransformer transformerUsingForwardBlock:^ id (NSString *digest, BOOL *success, NSError **error) {
+		return [digest isKindOfClass:NSString.class] ? digest.lowercaseString : nil;
+	}];
+}
+
+@end

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -17,6 +17,8 @@
 #import "SQRLDownloader.h"
 #import "SQRLShipItLauncher.h"
 #import "SQRLUpdate.h"
+#import "SQRLUpdateDelta.h"
+#import "SUBinaryDeltaApply.h"
 #import "SQRLZipArchiver.h"
 #import "SQRLShipItRequest.h"
 #import <ReactiveObjC/EXTScope.h>
@@ -117,12 +119,30 @@ BOOL isVersionStandard(NSString* version) {
 // errors, on a background thread.
 - (RACSignal *)downloadBundleForUpdate:(SQRLUpdate *)update intoDirectory:(NSURL *)downloadDirectory;
 
-// Checks a downloaded package against the size and digest its update declares.
+// Checks a downloaded file against a declared size and SHA-256 digest, deleting
+// it on mismatch.
 //
 // Returns a signal which completes, or errors with
 // `SQRLUpdaterErrorInvalidUpdatePackage`, on a background thread. Completes
-// immediately when the update declares neither.
-- (RACSignal *)verifyPackageAtURL:(NSURL *)packageURL forUpdate:(SQRLUpdate *)update;
+// immediately when neither is declared.
+- (RACSignal *)verifyFileAtURL:(NSURL *)fileURL size:(NSNumber *)size digest:(NSString *)digest;
+
+// Produces the verified update in `downloadDirectory`: from `update.delta`
+// applied to the running application when that delta targets the running
+// version, and otherwise, or if anything about the delta fails, from the
+// full archive at `update.updateURL`.
+//
+// Returns a signal which sends a `SQRLDownloadedUpdate` (or nil when a
+// conditional GET says the archive was already downloaded) then completes, or
+// errors, on a background thread.
+- (RACSignal *)downloadedUpdateForUpdate:(SQRLUpdate *)update intoDirectory:(NSURL *)downloadDirectory;
+
+// Downloads `delta`, verifies it, and applies it to a copy of the running
+// application inside `downloadDirectory`.
+//
+// Returns a signal which sends the patched `NSBundle` then completes, or
+// errors, on a background thread.
+- (RACSignal *)bundleByApplyingDelta:(SQRLUpdateDelta *)delta intoDirectory:(NSURL *)downloadDirectory;
 
 // Creates a unique directory in which to save the update bundle, for later use
 // by ShipIt.
@@ -140,17 +160,14 @@ BOOL isVersionStandard(NSString* version) {
 // errors.
 - (RACSignal *)updateBundleMatchingCurrentApplicationInDirectory:(NSURL *)directory;
 
-// Validates the code signature of the given update bundle, then prepares it for
-// installation.
+// Validates the code signature (and, with ElectronSquirrelPreventDowngrades,
+// the version) of the given update bundle.
 //
-// Upon success, the update will be automatically installed after the
-// application terminates.
-//
-// update - Describes the update to verify and prepare. This must not be nil.
+// update - Describes the update to verify. This must not be nil.
 //
 // Returns a signal which sends a `SQRLDownloadedUpdate` then completes, or
 // errors, on a background thread.
-- (RACSignal *)verifyAndPrepareUpdate:(SQRLUpdate *)update fromBundle:(NSBundle *)updateBundle;
+- (RACSignal *)verifyUpdate:(SQRLUpdate *)update fromBundle:(NSBundle *)updateBundle;
 
 // Prepares the given update for installation.
 //
@@ -482,16 +499,18 @@ BOOL isVersionStandard(NSString* version) {
 			};
 
 			return [[[self
-				downloadBundleForUpdate:update intoDirectory:downloadDirectory]
-				flattenMap:^(NSBundle *updateBundle) {
-					// If the bundle is nil it means our conditional GET told us
-					// we already downloaded the update. So just clean up.
-					if (updateBundle == nil) {
+				downloadedUpdateForUpdate:update intoDirectory:downloadDirectory]
+				flattenMap:^(SQRLDownloadedUpdate *downloadedUpdate) {
+					// Nil means our conditional GET told us we already
+					// downloaded the update. So just clean up.
+					if (downloadedUpdate == nil) {
 						cleanUp();
 						return [RACSignal empty];
 					}
 
-					return [self verifyAndPrepareUpdate:update fromBundle:updateBundle];
+					return [[self prepareUpdateForInstallation:downloadedUpdate] then:^{
+						return [RACSignal return:downloadedUpdate];
+					}];
 				}]
 				doError:^(id _) {
 					// The archive behind that ETag never became a prepared
@@ -501,6 +520,104 @@ BOOL isVersionStandard(NSString* version) {
 				}];
 		}]
 		setNameWithFormat:@"%@ -downloadAndPrepareUpdate: %@", self, update];
+}
+
+- (RACSignal *)downloadedUpdateForUpdate:(SQRLUpdate *)update intoDirectory:(NSURL *)downloadDirectory {
+	RACSignal *fullUpdate = [[self
+		downloadBundleForUpdate:update intoDirectory:downloadDirectory]
+		flattenMap:^(NSBundle *updateBundle) {
+			if (updateBundle == nil) return [RACSignal return:nil];
+			return [self verifyUpdate:update fromBundle:updateBundle];
+		}];
+
+	SQRLUpdateDelta *delta = update.delta;
+	if (delta == nil) return fullUpdate;
+
+	NSURL *runningURL = NSRunningApplication.currentApplication.bundleURL;
+	NSString *runningVersion = (runningURL == nil ? nil : [NSBundle bundleWithURL:runningURL].sqrl_bundleVersion);
+	if (![delta.fromVersion isEqual:runningVersion]) {
+		NSLog(@"Delta update is from %@ but %@ is running, downloading the full update instead", delta.fromVersion, runningVersion);
+		return fullUpdate;
+	}
+
+	return [[[[self
+		bundleByApplyingDelta:delta intoDirectory:downloadDirectory]
+		flattenMap:^(NSBundle *updateBundle) {
+			return [self verifyUpdate:update fromBundle:updateBundle];
+		}]
+		catch:^(NSError *error) {
+			NSLog(@"Delta update from %@ could not be used (%@), downloading the full update instead", delta.fromVersion, error.sqrl_verboseDescription);
+
+			NSFileManager *fileManager = [[NSFileManager alloc] init];
+			for (NSURL *leftover in [fileManager contentsOfDirectoryAtURL:downloadDirectory includingPropertiesForKeys:nil options:0 error:NULL]) {
+				[fileManager removeItemAtURL:leftover error:NULL];
+			}
+			return fullUpdate;
+		}]
+		setNameWithFormat:@"%@ -downloadedUpdateForUpdate: %@ intoDirectory: %@", self, update, downloadDirectory];
+}
+
+- (RACSignal *)bundleByApplyingDelta:(SQRLUpdateDelta *)delta intoDirectory:(NSURL *)downloadDirectory {
+	NSParameterAssert(delta != nil);
+	NSParameterAssert(downloadDirectory != nil);
+
+	return [[RACSignal
+		defer:^{
+			NSMutableURLRequest *request = [self.requestForDownload(delta.deltaURL) mutableCopy];
+			[request setValue:@"application/octet-stream" forHTTPHeaderField:@"Accept"];
+			[request setTimeoutInterval:SQURLUpdaterZipDownloadTimeoutSeconds];
+
+			// A fixed name: the URL is the server's, the directory is ours.
+			NSURL *deltaOutputURL = [downloadDirectory URLByAppendingPathComponent:@"update.delta"];
+			NSURL *resumeDataURL = [downloadDirectory.URLByDeletingLastPathComponent URLByAppendingPathComponent:SQRLUpdaterResumeDataFileName];
+			SQRLDownloader *downloader = [[SQRLDownloader alloc] initWithRequest:request resumeDataURL:resumeDataURL];
+			[downloader.progress subscribeNext:^(SQRLDownloadProgress *progress) {
+				[self->_downloadProgress sendNext:progress];
+			}];
+
+			return [[[downloader
+				downloadToURL:deltaOutputURL]
+				reduceEach:^(NSURLResponse *response, NSURL *deltaFileURL) {
+					if ([response isKindOfClass:NSHTTPURLResponse.class]) {
+						NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
+						if (statusCode < 200 || statusCode > 299) {
+							[NSFileManager.defaultManager removeItemAtURL:deltaFileURL error:NULL];
+							return [RACSignal error:[NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorInvalidServerResponse userInfo:@{
+								NSLocalizedDescriptionKey: [NSString stringWithFormat:NSLocalizedString(@"Delta download answered %ld", nil), (long)statusCode],
+								NSURLErrorKey: delta.deltaURL,
+							}]];
+						}
+					}
+
+					NSURL *sourceURL = NSRunningApplication.currentApplication.bundleURL.URLByResolvingSymlinksInPath;
+					NSURL *patchedURL = [downloadDirectory URLByAppendingPathComponent:sourceURL.lastPathComponent];
+					return [[[self
+						verifyFileAtURL:deltaFileURL size:delta.size digest:delta.digest]
+						then:^{
+							return [RACSignal startLazilyWithScheduler:[RACScheduler schedulerWithPriority:RACSchedulerPriorityBackground] block:^(id<RACSubscriber> subscriber) {
+								NSLog(@"Applying delta %@ to %@", deltaFileURL.lastPathComponent, sourceURL.path);
+								NSError *error = nil;
+								BOOL applied = applyBinaryDelta(sourceURL.path, patchedURL.path, deltaFileURL.path, NO, ^(double progress){}, &error);
+								[NSFileManager.defaultManager removeItemAtURL:deltaFileURL error:NULL];
+
+								if (applied) {
+									[subscriber sendCompleted];
+								} else {
+									[subscriber sendError:[NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorInvalidUpdatePackage userInfo:@{
+										NSLocalizedDescriptionKey: NSLocalizedString(@"Could not apply the delta update", nil),
+										NSURLErrorKey: delta.deltaURL,
+										NSUnderlyingErrorKey: error ?: [NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorInvalidUpdatePackage userInfo:nil],
+									}]];
+								}
+							}];
+						}]
+						then:^{
+							return [self updateBundleMatchingCurrentApplicationInDirectory:downloadDirectory];
+						}];
+				}]
+				flatten];
+		}]
+		setNameWithFormat:@"%@ -bundleByApplyingDelta: %@ intoDirectory: %@", self, delta, downloadDirectory];
 }
 
 - (RACSignal *)unarchiveAndPrepareZipAtURL:(NSURL *)zipURL intoDirectory:(NSURL *)downloadDirectory {
@@ -572,7 +689,7 @@ BOOL isVersionStandard(NSString* version) {
 
 					NSLog(@"Download completed to: %@", zipURL);
 					return [[self
-						verifyPackageAtURL:zipURL forUpdate:update]
+						verifyFileAtURL:zipURL size:update.packageSize digest:update.packageDigest]
 						then:^{
 							return [self unarchiveAndPrepareZipAtURL:zipURL intoDirectory:downloadDirectory];
 						}];
@@ -582,11 +699,10 @@ BOOL isVersionStandard(NSString* version) {
 		setNameWithFormat:@"%@ -downloadBundleForUpdate: %@ intoDirectory: %@", self, update, downloadDirectory];
 }
 
-- (RACSignal *)verifyPackageAtURL:(NSURL *)packageURL forUpdate:(SQRLUpdate *)update {
+- (RACSignal *)verifyFileAtURL:(NSURL *)packageURL size:(NSNumber *)expectedSize digest:(NSString *)expectedDigest {
 	NSParameterAssert(packageURL != nil);
-	NSParameterAssert(update != nil);
 
-	if (update.packageSize == nil && update.packageDigest == nil) return [RACSignal empty];
+	if (expectedSize == nil && expectedDigest == nil) return [RACSignal empty];
 
 	return [[RACSignal
 		defer:^{
@@ -596,20 +712,20 @@ BOOL isVersionStandard(NSString* version) {
 				NSDictionary *userInfo = @{
 					NSLocalizedDescriptionKey: NSLocalizedString(@"Update download failed", nil),
 					NSLocalizedRecoverySuggestionErrorKey: reason,
-					NSURLErrorKey: update.updateURL,
+					NSURLErrorKey: packageURL,
 				};
 				return [RACSignal error:[NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorInvalidUpdatePackage userInfo:userInfo]];
 			};
 
-			if (update.packageSize != nil) {
+			if (expectedSize != nil) {
 				NSNumber *size = nil;
 				[packageURL getResourceValue:&size forKey:NSURLFileSizeKey error:NULL];
-				if (![size isEqual:update.packageSize]) {
-					return reject([NSString stringWithFormat:NSLocalizedString(@"The update package is %@ bytes, expected %@.", nil), size, update.packageSize]);
+				if (![size isEqual:expectedSize]) {
+					return reject([NSString stringWithFormat:NSLocalizedString(@"The downloaded file is %@ bytes, expected %@.", nil), size, expectedSize]);
 				}
 			}
 
-			if (update.packageDigest != nil) {
+			if (expectedDigest != nil) {
 				NSInputStream *stream = [NSInputStream inputStreamWithURL:packageURL];
 				[stream open];
 
@@ -629,14 +745,14 @@ BOOL isVersionStandard(NSString* version) {
 				NSMutableString *hex = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
 				for (NSUInteger i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) [hex appendFormat:@"%02x", digest[i]];
 
-				if (![hex isEqualToString:update.packageDigest]) {
-					return reject([NSString stringWithFormat:NSLocalizedString(@"The update package digest is %@, expected %@.", nil), hex, update.packageDigest]);
+				if (![hex isEqualToString:expectedDigest]) {
+					return reject([NSString stringWithFormat:NSLocalizedString(@"The downloaded file digest is %@, expected %@.", nil), hex, expectedDigest]);
 				}
 			}
 
 			return [RACSignal empty];
 		}]
-		setNameWithFormat:@"%@ -verifyPackageAtURL: %@ forUpdate: %@", self, packageURL, update];
+		setNameWithFormat:@"%@ -verifyFileAtURL: %@", self, packageURL];
 }
 
 #pragma mark File Management
@@ -840,11 +956,11 @@ BOOL isVersionStandard(NSString* version) {
 
 #pragma mark Installing Updates
 
-- (RACSignal *)verifyAndPrepareUpdate:(SQRLUpdate *)update fromBundle:(NSBundle *)updateBundle {
+- (RACSignal *)verifyUpdate:(SQRLUpdate *)update fromBundle:(NSBundle *)updateBundle {
 	NSParameterAssert(update != nil);
 	NSParameterAssert(updateBundle != nil);
 
-	return [[[[self.signature
+	return [[[self.signature
 		verifyBundleAtURL:updateBundle.bundleURL]
 		then:^{
 			NSRunningApplication *currentApplication = NSRunningApplication.currentApplication;
@@ -894,12 +1010,7 @@ BOOL isVersionStandard(NSString* version) {
 			SQRLDownloadedUpdate *downloadedUpdate = [[SQRLDownloadedUpdate alloc] initWithUpdate:update bundle:updateBundle];
 			return [RACSignal return:downloadedUpdate];
 		}]
-		flattenMap:^(SQRLDownloadedUpdate *downloadedUpdate) {
-			return [[self prepareUpdateForInstallation:downloadedUpdate] then:^{
-				return [RACSignal return:downloadedUpdate];
-			}];
-		}]
-		setNameWithFormat:@"%@ -verifyAndPrepareUpdate: %@ fromBundle: %@", self, update, updateBundle];
+		setNameWithFormat:@"%@ -verifyUpdate: %@ fromBundle: %@", self, update, updateBundle];
 }
 
 - (RACSignal *)prepareUpdateForInstallation:(SQRLDownloadedUpdate *)update {

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -7,6 +7,7 @@
 //
 
 #import "SQRLUpdater.h"
+
 #import "NSBundle+SQRLVersionExtensions.h"
 #import "NSError+SQRLVerbosityExtensions.h"
 #import "NSProcessInfo+SQRLVersionExtensions.h"
@@ -25,6 +26,8 @@
 #import <ReactiveObjC/ReactiveObjC.h>
 #import <CommonCrypto/CommonDigest.h>
 #import <sys/mount.h>
+#import <sys/stat.h>
+#import <unistd.h>
 
 NSString * const SQRLUpdaterErrorDomain = @"SQRLUpdaterErrorDomain";
 NSString * const SQRLUpdaterServerDataErrorKey = @"SQRLUpdaterServerDataErrorKey";
@@ -51,6 +54,9 @@ static NSString * const SQRLUpdaterUniqueTemporaryDirectoryPrefix = @"update.";
 // Kept in the storage directory, beside the per-attempt update directories, so
 // an interrupted package download can continue on a later check or launch.
 static NSString * const SQRLUpdaterResumeDataFileName = @"download.resumedata";
+// The delta and the ZIP are different URLs; sharing one file would have each
+// downloader discard the other's resume data.
+static NSString * const SQRLUpdaterDeltaResumeDataFileName = @"delta.resumedata";
 
 // How much of an error response body to attach to the error.
 static const NSUInteger SQRLUpdaterServerDataErrorLimit = 64 * 1024;
@@ -78,6 +84,10 @@ BOOL isVersionStandard(NSString* version) {
 /// The etag of the currently downloaded update, nil if no update has been
 /// downloaded.
 @property (atomic, copy) NSString *etag;
+
+// Digest of the delta the staged update was made from. Plays the ETag's role
+// for the delta path: a later check offering the same delta has nothing to do.
+@property (atomic, copy) NSString *appliedDeltaDigest;
 
 // The code signature for the running application, used to check updates before
 // sending them to ShipIt.
@@ -516,6 +526,7 @@ BOOL isVersionStandard(NSString* version) {
 					// The archive behind that ETag never became a prepared
 					// update, so a 304 for it must not read as "already have it".
 					self.etag = nil;
+					self.appliedDeltaDigest = nil;
 					cleanUp();
 				}];
 		}]
@@ -523,38 +534,60 @@ BOOL isVersionStandard(NSString* version) {
 }
 
 - (RACSignal *)downloadedUpdateForUpdate:(SQRLUpdate *)update intoDirectory:(NSURL *)downloadDirectory {
-	RACSignal *fullUpdate = [[self
-		downloadBundleForUpdate:update intoDirectory:downloadDirectory]
-		flattenMap:^(NSBundle *updateBundle) {
-			if (updateBundle == nil) return [RACSignal return:nil];
-			return [self verifyUpdate:update fromBundle:updateBundle];
-		}];
+	RACSignal * (^fullUpdateIntoDirectory)(NSURL *) = ^(NSURL *directory) {
+		return [[self
+			downloadBundleForUpdate:update intoDirectory:directory]
+			flattenMap:^(NSBundle *updateBundle) {
+				if (updateBundle == nil) return [RACSignal return:nil];
+				return [self verifyUpdate:update fromBundle:updateBundle];
+			}];
+	};
 
 	SQRLUpdateDelta *delta = update.delta;
-	if (delta == nil) return fullUpdate;
+	if (delta == nil) return fullUpdateIntoDirectory(downloadDirectory);
 
 	NSURL *runningURL = NSRunningApplication.currentApplication.bundleURL;
 	NSString *runningVersion = (runningURL == nil ? nil : [NSBundle bundleWithURL:runningURL].sqrl_bundleVersion);
 	if (![delta.fromVersion isEqual:runningVersion]) {
 		NSLog(@"Delta update is from %@ but %@ is running, downloading the full update instead", delta.fromVersion, runningVersion);
-		return fullUpdate;
+		return fullUpdateIntoDirectory(downloadDirectory);
 	}
+
+	// Already applied and staged from this delta: nothing to download, the
+	// same answer a 304 gives the ZIP path.
+	if ([delta.digest isEqual:self.appliedDeltaDigest]) return [RACSignal return:nil];
 
 	return [[[[self
 		bundleByApplyingDelta:delta intoDirectory:downloadDirectory]
 		flattenMap:^(NSBundle *updateBundle) {
-			return [self verifyUpdate:update fromBundle:updateBundle];
+			return [[self verifyUpdate:update fromBundle:updateBundle] doCompleted:^{
+				self.appliedDeltaDigest = delta.digest;
+			}];
 		}]
 		catch:^(NSError *error) {
 			NSLog(@"Delta update from %@ could not be used (%@), downloading the full update instead", delta.fromVersion, error.sqrl_verboseDescription);
 
-			NSFileManager *fileManager = [[NSFileManager alloc] init];
-			for (NSURL *leftover in [fileManager contentsOfDirectoryAtURL:downloadDirectory includingPropertiesForKeys:nil options:0 error:NULL]) {
-				[fileManager removeItemAtURL:leftover error:NULL];
-			}
-			return fullUpdate;
+			// Whatever the apply left behind may not be removable (it copies
+			// file flags such as uchg from the running app), so the ZIP gets a
+			// directory of its own rather than this one emptied.
+			[self removeDirectoryClearingFlagsAtURL:downloadDirectory];
+			return [[self uniqueTemporaryDirectoryForUpdate] flattenMap:^(NSURL *freshDirectory) {
+				return fullUpdateIntoDirectory(freshDirectory);
+			}];
 		}]
 		setNameWithFormat:@"%@ -downloadedUpdateForUpdate: %@ intoDirectory: %@", self, update, downloadDirectory];
+}
+
+- (void)removeDirectoryClearingFlagsAtURL:(NSURL *)directoryURL {
+	NSFileManager *fileManager = [[NSFileManager alloc] init];
+	for (NSURL *itemURL in [fileManager enumeratorAtURL:directoryURL includingPropertiesForKeys:nil options:0 errorHandler:nil]) {
+		lchflags(itemURL.fileSystemRepresentation, 0);
+	}
+
+	NSError *error = nil;
+	if (![fileManager removeItemAtURL:directoryURL error:&error]) {
+		NSLog(@"Could not remove %@ after a failed delta: %@", directoryURL.path, error.sqrl_verboseDescription);
+	}
 }
 
 - (RACSignal *)bundleByApplyingDelta:(SQRLUpdateDelta *)delta intoDirectory:(NSURL *)downloadDirectory {
@@ -569,7 +602,7 @@ BOOL isVersionStandard(NSString* version) {
 
 			// A fixed name: the URL is the server's, the directory is ours.
 			NSURL *deltaOutputURL = [downloadDirectory URLByAppendingPathComponent:@"update.delta"];
-			NSURL *resumeDataURL = [downloadDirectory.URLByDeletingLastPathComponent URLByAppendingPathComponent:SQRLUpdaterResumeDataFileName];
+			NSURL *resumeDataURL = [downloadDirectory.URLByDeletingLastPathComponent URLByAppendingPathComponent:SQRLUpdaterDeltaResumeDataFileName];
 			SQRLDownloader *downloader = [[SQRLDownloader alloc] initWithRequest:request resumeDataURL:resumeDataURL];
 			[downloader.progress subscribeNext:^(SQRLDownloadProgress *progress) {
 				[self->_downloadProgress sendNext:progress];

--- a/Squirrel/SQRLUpdater.m
+++ b/Squirrel/SQRLUpdater.m
@@ -89,6 +89,11 @@ BOOL isVersionStandard(NSString* version) {
 // for the delta path: a later check offering the same delta has nothing to do.
 @property (atomic, copy) NSString *appliedDeltaDigest;
 
+// Digest of a delta that downloaded intact but would not apply or verify.
+// That does not change within a process, so later checks go straight to the
+// ZIP instead of fetching and applying it again.
+@property (atomic, copy) NSString *unusableDeltaDigest;
+
 // The code signature for the running application, used to check updates before
 // sending them to ShipIt.
 @property (nonatomic, strong, readonly) SQRLCodeSignature *signature;
@@ -503,7 +508,7 @@ BOOL isVersionStandard(NSString* version) {
 		flattenMap:^(NSURL *downloadDirectory) {
 			void (^cleanUp)(void) = ^{
 				NSError *error;
-				if (![NSFileManager.defaultManager removeItemAtURL:downloadDirectory error:&error]) {
+				if ([downloadDirectory checkResourceIsReachableAndReturnError:NULL] && ![NSFileManager.defaultManager removeItemAtURL:downloadDirectory error:&error]) {
 					NSLog(@"Error removing temporary download directory at %@: %@", downloadDirectory, error.sqrl_verboseDescription);
 				}
 			};
@@ -556,37 +561,52 @@ BOOL isVersionStandard(NSString* version) {
 	// Already applied and staged from this delta: nothing to download, the
 	// same answer a 304 gives the ZIP path.
 	if ([delta.digest isEqual:self.appliedDeltaDigest]) return [RACSignal return:nil];
+	if ([delta.digest isEqual:self.unusableDeltaDigest]) return fullUpdateIntoDirectory(downloadDirectory);
 
 	return [[[[self
 		bundleByApplyingDelta:delta intoDirectory:downloadDirectory]
 		flattenMap:^(NSBundle *updateBundle) {
-			return [[self verifyUpdate:update fromBundle:updateBundle] doCompleted:^{
-				self.appliedDeltaDigest = delta.digest;
-			}];
+			// The apply copies file flags (a Finder-locked file's uchg) over
+			// from the running app; ShipIt cannot strip xattrs from or replace
+			// an immutable file, so the staged copy carries none.
+			[self clearFileFlagsUnderURL:updateBundle.bundleURL];
+			return [[[self
+				verifyUpdate:update fromBundle:updateBundle]
+				doError:^(NSError *error) {
+					self.unusableDeltaDigest = delta.digest;
+				}]
+				doCompleted:^{
+					self.appliedDeltaDigest = delta.digest;
+				}];
 		}]
 		catch:^(NSError *error) {
 			NSLog(@"Delta update from %@ could not be used (%@), downloading the full update instead", delta.fromVersion, error.sqrl_verboseDescription);
 
-			// Whatever the apply left behind may not be removable (it copies
-			// file flags such as uchg from the running app), so the ZIP gets a
-			// directory of its own rather than this one emptied.
-			[self removeDirectoryClearingFlagsAtURL:downloadDirectory];
+			// Whatever the apply left behind may not be removable as is (it has
+			// the running app's file flags), so clear those, remove it, and
+			// give the ZIP a directory of its own either way.
+			[self clearFileFlagsUnderURL:downloadDirectory];
+			NSError *removeError = nil;
+			if (![NSFileManager.defaultManager removeItemAtURL:downloadDirectory error:&removeError]) {
+				NSLog(@"Could not remove %@ after a failed delta: %@", downloadDirectory.path, removeError.sqrl_verboseDescription);
+			}
+
 			return [[self uniqueTemporaryDirectoryForUpdate] flattenMap:^(NSURL *freshDirectory) {
-				return fullUpdateIntoDirectory(freshDirectory);
+				return [[fullUpdateIntoDirectory(freshDirectory)
+					doNext:^(SQRLDownloadedUpdate *downloadedUpdate) {
+						if (downloadedUpdate == nil) [NSFileManager.defaultManager removeItemAtURL:freshDirectory error:NULL];
+					}]
+					doError:^(NSError *error) {
+						[NSFileManager.defaultManager removeItemAtURL:freshDirectory error:NULL];
+					}];
 			}];
 		}]
 		setNameWithFormat:@"%@ -downloadedUpdateForUpdate: %@ intoDirectory: %@", self, update, downloadDirectory];
 }
 
-- (void)removeDirectoryClearingFlagsAtURL:(NSURL *)directoryURL {
-	NSFileManager *fileManager = [[NSFileManager alloc] init];
-	for (NSURL *itemURL in [fileManager enumeratorAtURL:directoryURL includingPropertiesForKeys:nil options:0 errorHandler:nil]) {
+- (void)clearFileFlagsUnderURL:(NSURL *)directoryURL {
+	for (NSURL *itemURL in [NSFileManager.defaultManager enumeratorAtURL:directoryURL includingPropertiesForKeys:nil options:0 errorHandler:nil]) {
 		lchflags(itemURL.fileSystemRepresentation, 0);
-	}
-
-	NSError *error = nil;
-	if (![fileManager removeItemAtURL:directoryURL error:&error]) {
-		NSLog(@"Could not remove %@ after a failed delta: %@", directoryURL.path, error.sqrl_verboseDescription);
 	}
 }
 
@@ -636,6 +656,7 @@ BOOL isVersionStandard(NSString* version) {
 								if (applied) {
 									[subscriber sendCompleted];
 								} else {
+									self.unusableDeltaDigest = delta.digest;
 									[subscriber sendError:[NSError errorWithDomain:SQRLUpdaterErrorDomain code:SQRLUpdaterErrorInvalidUpdatePackage userInfo:@{
 										NSLocalizedDescriptionKey: NSLocalizedString(@"Could not apply the delta update", nil),
 										NSURLErrorKey: delta.deltaURL,

--- a/Squirrel/SparkleDelta/SparkleDeltaConfig.h
+++ b/Squirrel/SparkleDelta/SparkleDeltaConfig.h
@@ -1,0 +1,16 @@
+// Build configuration for the Sparkle BinaryDelta sources Squirrel compiles
+// out of the Sparkle submodule (Carthage/Checkouts/Sparkle). Sparkle sets these
+// from its xcconfigs; Squirrel force-includes this header instead.
+
+// Only Sparkle's own container format (delta major versions 3 and 4) is read;
+// the XAR-based formats 1 and 2 are not built.
+#define SPARKLE_BUILD_LEGACY_DELTA_SUPPORT 0
+// LZMA/LZFSE/LZ4/ZLIB via libcompression only.
+#define SPARKLE_BUILD_BZIP2_DELTA_SUPPORT 0
+
+// Sparkle marks these classes objc_direct as a size optimisation; direct
+// methods are not visible across image boundaries, and the tests create
+// deltas with Sparkle's generator linked against this framework's archive
+// classes, so keep ordinary dispatch.
+#define SPU_OBJC_DIRECT
+#define SPU_OBJC_DIRECT_MEMBERS

--- a/Squirrel/SparkleDelta/SparkleDeltaConfig.h
+++ b/Squirrel/SparkleDelta/SparkleDeltaConfig.h
@@ -5,7 +5,9 @@
 // Only Sparkle's own container format (delta major versions 3 and 4) is read;
 // the XAR-based formats 1 and 2 are not built.
 #define SPARKLE_BUILD_LEGACY_DELTA_SUPPORT 0
-// LZMA/LZFSE/LZ4/ZLIB via libcompression only.
+// Containers compressed with LZMA/LZFSE/LZ4/ZLIB (libcompression) are read;
+// a `--compression bzip2` container is refused. The per-file bsdiff patches
+// inside any container are still bzip2, which is what libbz2 is linked for.
 #define SPARKLE_BUILD_BZIP2_DELTA_SUPPORT 0
 
 // Sparkle marks these classes objc_direct as a size optimisation; direct

--- a/Squirrel/Squirrel.h
+++ b/Squirrel/Squirrel.h
@@ -20,3 +20,4 @@ FOUNDATION_EXPORT const unsigned char SquirrelVersionString[];
 #import <Squirrel/SQRLDownloader.h>
 #import <Squirrel/SQRLUpdater.h>
 #import <Squirrel/SQRLUpdate.h>
+#import <Squirrel/SQRLUpdateDelta.h>

--- a/SquirrelTests/SQRLUpdateSpec.m
+++ b/SquirrelTests/SQRLUpdateSpec.m
@@ -74,7 +74,10 @@ it(@"should parse a delta and drop one it cannot use", ^{
 		bad[key] = value;
 		return bad;
 	};
-	NSArray *unusable = @[ @"soon", with(@"from_version", nil), with(@"from_version", @412), with(@"url", nil), with(@"sha256", @"abc"), with(@"sha256", [digest stringByReplacingCharactersInRange:NSMakeRange(0, 1) withString:@"g"]), with(@"size", nil), with(@"size", @0) ];
+	update = [MTLJSONAdapter modelOfClass:SQRLUpdate.class fromJSONDictionary:@{ @"url": @"http://example.com/update", @"delta": with(@"from_version", @412) } error:NULL];
+	expect(update.delta.fromVersion).to(equal(@"412"));
+
+	NSArray *unusable = @[ @"soon", with(@"from_version", nil), with(@"url", nil), with(@"sha256", @"abc"), with(@"sha256", [digest stringByReplacingCharactersInRange:NSMakeRange(0, 1) withString:@"g"]), with(@"size", nil), with(@"size", @0), with(@"size", @1.5), with(@"size", @YES) ];
 	for (id bad in unusable) {
 		update = [MTLJSONAdapter modelOfClass:SQRLUpdate.class fromJSONDictionary:@{ @"url": @"http://example.com/update", @"delta": bad } error:NULL];
 		expect(update).notTo(beNil());

--- a/SquirrelTests/SQRLUpdateSpec.m
+++ b/SquirrelTests/SQRLUpdateSpec.m
@@ -60,6 +60,28 @@ it(@"should parse the package digest and size, ignoring values it cannot use", ^
 	}
 });
 
+it(@"should parse a delta and drop one it cannot use", ^{
+	NSString *digest = [@"" stringByPaddingToLength:64 withString:@"A1" startingAtIndex:0];
+	NSDictionary *delta = @{ @"from_version": @"1.2.3", @"url": @"http://example.com/1.2.3-to-1.2.4.delta", @"sha256": digest, @"size": @99 };
+	SQRLUpdate *update = [MTLJSONAdapter modelOfClass:SQRLUpdate.class fromJSONDictionary:@{ @"url": @"http://example.com/update", @"delta": delta } error:NULL];
+	expect(update.delta.fromVersion).to(equal(@"1.2.3"));
+	expect(update.delta.deltaURL).to(equal([NSURL URLWithString:@"http://example.com/1.2.3-to-1.2.4.delta"]));
+	expect(update.delta.digest).to(equal(digest.lowercaseString));
+	expect(update.delta.size).to(equal(@99));
+
+	NSDictionary * (^with)(NSString *, id) = ^(NSString *key, id value) {
+		NSMutableDictionary *bad = [delta mutableCopy];
+		bad[key] = value;
+		return bad;
+	};
+	NSArray *unusable = @[ @"soon", with(@"from_version", nil), with(@"from_version", @412), with(@"url", nil), with(@"sha256", @"abc"), with(@"sha256", [digest stringByReplacingCharactersInRange:NSMakeRange(0, 1) withString:@"g"]), with(@"size", nil), with(@"size", @0) ];
+	for (id bad in unusable) {
+		update = [MTLJSONAdapter modelOfClass:SQRLUpdate.class fromJSONDictionary:@{ @"url": @"http://example.com/update", @"delta": bad } error:NULL];
+		expect(update).notTo(beNil());
+		expect(update.delta).to(beNil());
+	}
+});
+
 it(@"should parse Central style dates", ^{
 	SQRLUpdate *update = [MTLJSONAdapter modelOfClass:SQRLUpdate.class fromJSONDictionary:@{ @"url": @"http://example.com/update", @"pub_date": @"Tue Sep 17 10:24:27 -0700 2013" } error:NULL];
 	expect(update.releaseDate).to(equal([NSDate dateWithTimeIntervalSince1970:1379438667]));

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -446,16 +446,19 @@ describe(@"updating", ^{
 			return paths;
 		};
 
-		SQRLUpdateDelta * (^servedDelta)(BOOL) = ^(BOOL intact) {
+		// A delta from `fromURL` to the update, served as /update.delta with
+		// `corrupt` of its bytes overwritten first (digest and size describe
+		// what is served, so the download itself always verifies).
+		SQRLUpdateDelta * (^servedDelta)(NSURL *, NSRange) = ^(NSURL *fromURL, NSRange corrupt) {
 			NSURL *deltaURL = [serverDirectoryURL URLByAppendingPathComponent:@"update.delta"];
 			NSError *error = nil;
-			BOOL created = createBinaryDelta(self.testApplicationURL.path, updateURL.path, deltaURL.path, SUBinaryDeltaMajorVersion4, SPUDeltaCompressionModeDefault, 0, NO, &error);
+			BOOL created = createBinaryDelta(fromURL.path, updateURL.path, deltaURL.path, SUBinaryDeltaMajorVersion4, SPUDeltaCompressionModeDefault, 0, NO, &error);
 			expect(@(created)).to(beTruthy());
 			expect(error).to(beNil());
 
 			NSMutableData *contents = [NSMutableData dataWithContentsOfURL:deltaURL];
-			if (!intact) {
-				memset(contents.mutableBytes, 'x', contents.length);
+			if (corrupt.length > 0) {
+				memset((char *)contents.mutableBytes + corrupt.location, 'x', corrupt.length);
 				[contents writeToURL:deltaURL atomically:YES];
 			}
 			unsigned char digest[CC_SHA256_DIGEST_LENGTH];
@@ -471,7 +474,13 @@ describe(@"updating", ^{
 			} error:NULL];
 		};
 
-		void (^updateWithDelta)(SQRLUpdateDelta *) = ^(SQRLUpdateDelta *delta) {
+		SQRLUpdateDelta * (^deltaWith)(SQRLUpdateDelta *, NSDictionary *) = ^(SQRLUpdateDelta *delta, NSDictionary *overrides) {
+			NSMutableDictionary *JSON = [[MTLJSONAdapter JSONDictionaryFromModel:delta error:NULL] mutableCopy];
+			[JSON addEntriesFromDictionary:overrides];
+			return [MTLJSONAdapter modelOfClass:SQRLUpdateDelta.class fromJSONDictionary:JSON error:NULL];
+		};
+
+		void (^updateWithDelta)(SQRLUpdateDelta *, NSDictionary *) = ^(SQRLUpdateDelta *delta, NSDictionary *environment) {
 			SQRLTestUpdate *update = [SQRLTestUpdate modelWithDictionary:@{
 				@"updateURL": [baseURL URLByAppendingPathComponent:@"full.zip"],
 				@"delta": delta,
@@ -479,19 +488,62 @@ describe(@"updating", ^{
 			} error:NULL];
 			writeUpdate(update);
 
-			NSRunningApplication *app = launchWithEnvironment(nil);
+			NSRunningApplication *app = launchWithEnvironment(environment);
 			expect(@(app.terminated)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
 			[self waitForShipItJobToExitWithLabel:@"com.github.Squirrel.TestApplication.ShipIt"];
 			expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationUpdatedShortVersionString));
 		};
 
+		NSRange const intact = { 0, 0 };
+
 		it(@"should install from the delta alone", ^{
-			updateWithDelta(servedDelta(YES));
+			updateWithDelta(servedDelta(self.testApplicationURL, intact), nil);
 			expect(requestedPaths()).to(equal(@[ @"/update.delta" ]));
 		});
 
+		it(@"should not fetch a delta it has already staged on a later check", ^{
+			updateWithDelta(servedDelta(self.testApplicationURL, intact), @{ @"SQRLUpdateRequestCount": @"2" });
+			expect(requestedPaths()).to(equal(@[ @"/update.delta" ]));
+		});
+
+		it(@"should apply a delta made from the shipped bundles to a ShipIt-installed copy", ^{
+			// What happens in the field: the running app went through ShipIt
+			// (which normalises modes and ownership), the delta was made from
+			// the bundles as built.
+			NSURL *shippedURL = [[NSBundle bundleForClass:self.class] URLForResource:@"TestApplication" withExtension:@"app"];
+			[NSFileManager.defaultManager copyItemAtURL:zipUpdate(shippedURL) toURL:[serverDirectoryURL URLByAppendingPathComponent:@"same.zip"] error:NULL];
+			writeUpdate([SQRLTestUpdate modelWithDictionary:@{
+				@"updateURL": [baseURL URLByAppendingPathComponent:@"same.zip"],
+				@"final": @YES
+			} error:NULL]);
+			NSRunningApplication *app = launchWithEnvironment(nil);
+			expect(@(app.terminated)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
+			[self waitForShipItJobToExitWithLabel:@"com.github.Squirrel.TestApplication.ShipIt"];
+
+			updateWithDelta(servedDelta(shippedURL, intact), nil);
+			expect(requestedPaths()).to(equal(@[ @"/same.zip", @"/update.delta" ]));
+		});
+
+		it(@"should not request a delta made from another version", ^{
+			updateWithDelta(deltaWith(servedDelta(self.testApplicationURL, intact), @{ @"from_version": @"0" }), nil);
+			expect(requestedPaths()).to(equal(@[ @"/full.zip" ]));
+		});
+
+		it(@"should fall back to the full update when the delta is not the one described", ^{
+			updateWithDelta(deltaWith(servedDelta(self.testApplicationURL, intact), @{ @"sha256": [@"" stringByPaddingToLength:64 withString:@"0" startingAtIndex:0] }), nil);
+			expect(requestedPaths()).to(equal(@[ @"/update.delta", @"/full.zip" ]));
+		});
+
 		it(@"should fall back to the full update when the delta does not apply", ^{
-			updateWithDelta(servedDelta(NO));
+			updateWithDelta(servedDelta(self.testApplicationURL, NSMakeRange(0, 64)), nil);
+			expect(requestedPaths()).to(equal(@[ @"/update.delta", @"/full.zip" ]));
+		});
+
+		it(@"should fall back to the full update when the delta fails part way through applying", ^{
+			// Header and tree hashes intact, payload damaged: the apply has
+			// already written into the update directory when it gives up.
+			NSUInteger size = servedDelta(self.testApplicationURL, intact).size.unsignedIntegerValue;
+			updateWithDelta(servedDelta(self.testApplicationURL, NSMakeRange(size - size / 3, size / 3)), nil);
 			expect(requestedPaths()).to(equal(@[ @"/update.delta", @"/full.zip" ]));
 		});
 	});

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -11,6 +11,8 @@
 #import <ReactiveObjC/ReactiveObjC.h>
 #import <Squirrel/Squirrel.h>
 #import <CommonCrypto/CommonDigest.h>
+#import <sys/stat.h>
+#import <unistd.h>
 
 #import "SQRLDirectoryManager.h"
 #import "SQRLShipItLauncher.h"
@@ -537,6 +539,42 @@ describe(@"updating", ^{
 		it(@"should fall back to the full update when the delta does not apply", ^{
 			updateWithDelta(servedDelta(self.testApplicationURL, NSMakeRange(0, 64)), nil);
 			expect(requestedPaths()).to(equal(@[ @"/update.delta", @"/full.zip" ]));
+		});
+
+		// Finder's "Locked" checkbox: sets uchg on a file inside the running
+		// app, which the apply copies onto its clone.
+		void (^lockRunningFile)(NSString *) = ^(NSString *relativePath) {
+			const char *path = [self.testApplicationURL URLByAppendingPathComponent:relativePath].fileSystemRepresentation;
+			expect(@(chflags(path, UF_IMMUTABLE))).to(equal(@0));
+			NSURL *temporaryDirectoryURL = self.temporaryDirectoryURL;
+			[self addCleanupBlock:^{
+				// The install moves the locked original aside under here.
+				for (NSURL *itemURL in [NSFileManager.defaultManager enumeratorAtURL:temporaryDirectoryURL includingPropertiesForKeys:nil options:0 errorHandler:nil]) lchflags(itemURL.fileSystemRepresentation, 0);
+			}];
+		};
+
+		NSArray * (^lockedItemsInUpdateStorage)(void) = ^{
+			NSURL *storageURL = [[[SQRLDirectoryManager alloc] initWithApplicationIdentifier:@"com.github.Squirrel.TestApplication.ShipIt"] storageURL].first;
+			NSMutableArray *locked = [NSMutableArray array];
+			for (NSURL *itemURL in [NSFileManager.defaultManager enumeratorAtURL:storageURL includingPropertiesForKeys:@[ NSURLIsUserImmutableKey ] options:0 errorHandler:nil]) {
+				NSNumber *immutable = nil;
+				[itemURL getResourceValue:&immutable forKey:NSURLIsUserImmutableKey error:NULL];
+				if (immutable.boolValue) [locked addObject:itemURL.path];
+			}
+			return locked;
+		};
+
+		it(@"should install from a delta when the running app has a locked file the delta leaves alone", ^{
+			lockRunningFile(@"Contents/PkgInfo");
+			updateWithDelta(servedDelta(self.testApplicationURL, intact), nil);
+			expect(requestedPaths()).to(equal(@[ @"/update.delta" ]));
+		});
+
+		it(@"should fall back to the full update and clean up when a locked file stops the delta applying", ^{
+			lockRunningFile(@"Contents/Info.plist");
+			updateWithDelta(servedDelta(self.testApplicationURL, intact), nil);
+			expect(requestedPaths()).to(equal(@[ @"/update.delta", @"/full.zip" ]));
+			expect(lockedItemsInUpdateStorage()).to(equal(@[]));
 		});
 
 		it(@"should fall back to the full update when the delta fails part way through applying", ^{

--- a/SquirrelTests/SQRLUpdaterSpec.m
+++ b/SquirrelTests/SQRLUpdaterSpec.m
@@ -20,6 +20,8 @@
 #import "OHHTTPStubs/OHHTTPStubs.h"
 #import "QuickSpec+SQRLFixtures.h"
 #import "SQRLTestUpdate.h"
+#import "SUBinaryDeltaCreate.h"
+#import <CommonCrypto/CommonDigest.h>
 #import "TestAppConstants.h"
 #import <objc/objc-class.h>
 
@@ -422,6 +424,76 @@ describe(@"updating", ^{
 		expect(@(app.terminated)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
 		[self waitForShipItJobToExitWithLabel:@"com.github.Squirrel.TestApplication.ShipIt"];
 		expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationUpdatedShortVersionString));
+	});
+
+	describe(@"with a delta", ^{
+		__block NSURL *serverDirectoryURL;
+		__block NSURL *baseURL;
+		__block NSURL *requestLogURL;
+
+		beforeEach(^{
+			serverDirectoryURL = [self.temporaryDirectoryURL URLByAppendingPathComponent:@"served" isDirectory:YES];
+			[NSFileManager.defaultManager createDirectoryAtURL:serverDirectoryURL withIntermediateDirectories:YES attributes:nil error:NULL];
+			[NSFileManager.defaultManager copyItemAtURL:zipUpdate(updateURL) toURL:[serverDirectoryURL URLByAppendingPathComponent:@"full.zip"] error:NULL];
+			baseURL = [self startTestServerForDirectory:serverDirectoryURL requestLog:&requestLogURL];
+		});
+
+		NSArray * (^requestedPaths)(void) = ^{
+			NSMutableArray *paths = [NSMutableArray array];
+			for (NSString *line in [[NSString stringWithContentsOfURL:requestLogURL encoding:NSUTF8StringEncoding error:NULL] componentsSeparatedByString:@"\n"]) {
+				if (line.length > 0) [paths addObject:[line componentsSeparatedByString:@" "][1]];
+			}
+			return paths;
+		};
+
+		SQRLUpdateDelta * (^servedDelta)(BOOL) = ^(BOOL intact) {
+			NSURL *deltaURL = [serverDirectoryURL URLByAppendingPathComponent:@"update.delta"];
+			NSError *error = nil;
+			BOOL created = createBinaryDelta(self.testApplicationURL.path, updateURL.path, deltaURL.path, SUBinaryDeltaMajorVersion4, SPUDeltaCompressionModeDefault, 0, NO, &error);
+			expect(@(created)).to(beTruthy());
+			expect(error).to(beNil());
+
+			NSMutableData *contents = [NSMutableData dataWithContentsOfURL:deltaURL];
+			if (!intact) {
+				memset(contents.mutableBytes, 'x', contents.length);
+				[contents writeToURL:deltaURL atomically:YES];
+			}
+			unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+			CC_SHA256(contents.bytes, (CC_LONG)contents.length, digest);
+			NSMutableString *hex = [NSMutableString string];
+			for (NSUInteger i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) [hex appendFormat:@"%02x", digest[i]];
+
+			return [MTLJSONAdapter modelOfClass:SQRLUpdateDelta.class fromJSONDictionary:@{
+				@"from_version": self.testApplicationBundle.sqrl_bundleVersion,
+				@"url": [baseURL URLByAppendingPathComponent:@"update.delta"].absoluteString,
+				@"sha256": hex,
+				@"size": @(contents.length),
+			} error:NULL];
+		};
+
+		void (^updateWithDelta)(SQRLUpdateDelta *) = ^(SQRLUpdateDelta *delta) {
+			SQRLTestUpdate *update = [SQRLTestUpdate modelWithDictionary:@{
+				@"updateURL": [baseURL URLByAppendingPathComponent:@"full.zip"],
+				@"delta": delta,
+				@"final": @YES
+			} error:NULL];
+			writeUpdate(update);
+
+			NSRunningApplication *app = launchWithEnvironment(nil);
+			expect(@(app.terminated)).withTimeout(SQRLLongTimeout).toEventually(beTruthy());
+			[self waitForShipItJobToExitWithLabel:@"com.github.Squirrel.TestApplication.ShipIt"];
+			expect(self.testApplicationBundleVersion).to(equal(SQRLTestApplicationUpdatedShortVersionString));
+		};
+
+		it(@"should install from the delta alone", ^{
+			updateWithDelta(servedDelta(YES));
+			expect(requestedPaths()).to(equal(@[ @"/update.delta" ]));
+		});
+
+		it(@"should fall back to the full update when the delta does not apply", ^{
+			updateWithDelta(servedDelta(NO));
+			expect(requestedPaths()).to(equal(@[ @"/update.delta", @"/full.zip" ]));
+		});
 	});
 
 	it(@"should not install a corrupt update", ^{

--- a/TestApplication/TestAppDelegate.m
+++ b/TestApplication/TestAppDelegate.m
@@ -80,12 +80,15 @@
 			NSLog(@"***** UPDATE CHECK %lu *****", (unsigned long)updateCheckCount);
 			updateCheckCount++;
 
-			return [self.updater.checkForUpdatesCommand execute:RACUnit.defaultUnit];
+			return [[self.updater.checkForUpdatesCommand
+				execute:RACUnit.defaultUnit]
+				concat:[[RACSignal empty] delay:0.2]];
 		}]
 		doNext:^(SQRLDownloadedUpdate *update) {
 			NSLog(@"Got a candidate update: %@", update);
 		}]
-		// Retry until we get the expected release.
+		// Retry until we get the expected release (a check that yields
+		// nothing, e.g. an update already staged, is retried after 0.2s).
 		repeat]
 		skipUntilBlock:^(SQRLDownloadedUpdate *download) {
 			SQRLTestUpdate *testUpdate = (id)download.update;


### PR DESCRIPTION
Stacked on #327 (base branch `stream-and-resume-downloads`); the diff here is only the delta work.

An update may now carry `delta`: a [Sparkle](https://sparkle-project.org) BinaryDelta patch (format 3 or 4) from one earlier `CFBundleVersion` to this release, with its URL, size and SHA-256:

```json
"delta": { "from_version": "412", "url": "https://…/412-to-413.delta", "sha256": "…", "size": 7340032 }
```

When `from_version` is the running application's, Squirrel downloads the patch instead of the ZIP (same streaming, resumable `SQRLDownloader`), checks size and digest before opening it, applies it to a copy of the running bundle inside the update directory, and sends the result through the existing code signing and `ElectronSquirrelPreventDowngrades` checks. If the delta is for another version, or downloading, verifying, applying or checking it fails in any way, the full ZIP is downloaded in the same check, so offering a delta can never cost an update. All four keys are required; ShipIt and installation are untouched.

The apply side is Sparkle's own, vendored unmodified under `Vendor/SparkleDelta` (MIT; format 3/4 reader and applier plus `bspatch`, ~2.9k lines, pinned to sparkle-project/Sparkle@cfa1190) with a small force-included config header standing in for Sparkle's xcconfig defines; the legacy XAR formats and the create side are left out, so patches are made with Sparkle's `BinaryDelta create old.app new.app out.delta` from the exact signed bundles that shipped. That keeps one implementation of the format rather than a Squirrel-flavoured second one. `objc_direct` is turned off for the vendored classes so the tests can link Sparkle's generator against them.

Sizing, for a sense of why: between two consecutive releases of a large Electron app (~230 MB zipped per arch, same Electron version) the format-4 LZMA delta is 9.5 MB, applies in a few seconds, and the result is byte-identical to the shipped bundle and passes `codesign --verify --deep --strict` and Gatekeeper.

Tests: `SQRLUpdaterSpec` builds real patches between the two TestApplication fixtures with Sparkle's generator (vendored into the test target only) and drives the out-of-process install twice, once from the delta alone (ZIP never requested) and once with a corrupted delta that must fall back to the ZIP, asserting on the fixture server's request log which files were fetched; `SQRLUpdateSpec` covers parsing and rejects a delta missing any key. 97 tests pass on macOS 26.5 / Xcode 26.5. README documents the key in both feed formats