### PR TITLE
chore: remove the unused Cartfiles

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,0 @@
-github "Mantle/Mantle" ~> 2.2
-github "ReactiveCocoa/ReactiveObjC" ~> 3.1

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,0 @@
-github "jspahrsummers/xcconfigs" ~> 0.8.1
-github "Quick/Quick" ~> 5.0
-github "Quick/Nimble" ~> 9.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,0 @@
-github "Mantle/Mantle" "2a8e2123a3931038179ee06105c9e6ec336b12ea"
-github "Quick/Nimble" "v9.2.1"
-github "Quick/Quick" "v5.0.1"
-github "ReactiveCocoa/ReactiveObjC" "74ab5baccc6f7202c8ac69a8d1e152c29dc1ea76"
-github "jspahrsummers/xcconfigs" "0.8.1"

--- a/README.md
+++ b/README.md
@@ -39,21 +39,24 @@ If you’re developing Squirrel on its own, then use `Squirrel.xcworkspace`.
 
 # Dependencies
 
-Squirrel depends on [ReactiveCocoa](http://github.com/ReactiveCocoa/ReactiveCocoa)
-and [Mantle](https://github.com/Mantle/Mantle).
+Squirrel depends on [ReactiveObjC](https://github.com/ReactiveCocoa/ReactiveObjC)
+and [Mantle](https://github.com/Mantle/Mantle). Both are git submodules of this
+repository (under `Carthage/Checkouts/`, a directory name kept from when they
+were fetched with Carthage); `git submodule update --init` or `script/bootstrap`
+checks them out.
 
-If your application is already using ReactiveCocoa, ensure it is using the same
+If your application is already using ReactiveObjC, ensure it is using the same
 version as Squirrel.
 
 Otherwise, add a target dependency and Copy Files build phase entry for the
-ReactiveCocoa.framework target included in Squirrel's repository, in
-`Carthage/Checkouts/ReactiveCocoa`.
+ReactiveObjC.framework target included in Squirrel's repository, in
+`Carthage/Checkouts/ReactiveObjC`.
 
 Similarly, ensure your application includes Mantle, or copies in the Squirrel
 version.
 
 Finally, ensure your application's Runpath Search Paths (`LD_RUNPATH_SEARCH_PATHS`)
-includes the directory that Squirrel.framework, ReactiveCocoa.framework
+includes the directory that Squirrel.framework, ReactiveObjC.framework
 and Mantle.framework are copied into.
 
 # Configuration


### PR DESCRIPTION
Nothing in the repo runs Carthage: the dependencies are plain git submodules that CI (`git submodule update --init --depth 1 …`) and `script/bootstrap` initialise and that the workspace references directly, and `Cartfile.resolved` had drifted from the submodule pins (it lists Mantle 2.2 / ReactiveObjC 3.1 tags while the submodules sit on specific commits). This deletes `Cartfile`, `Cartfile.private` and `Cartfile.resolved`, and rewrites the README's Dependencies section to say "submodules" and "ReactiveObjC" (it still said ReactiveCocoa and pointed at a `Carthage/Checkouts/ReactiveCocoa` path that no longer exists).

The `Carthage/Checkouts/` directory name is left alone to keep the diff to the four files; renaming it would touch the workspace, project, `.gitmodules`, CI and bootstrap and can be its own change if wanted.
