### PR TITLE
fix: stop the stderr readability handler at EOF and on task termination

### DIFF
--- a/Squirrel/SQRLZipArchiver.m
+++ b/Squirrel/SQRLZipArchiver.m
@@ -62,13 +62,21 @@ const NSInteger SQRLZipArchiverShellTaskFailed = 1;
 		@strongify(self);
 		if (self == nil) return;
 
+		NSFileHandle *standardError = self.standardErrorPipe.fileHandleForReading;
+		standardError.readabilityHandler = nil;
 		[self->_taskTerminated sendNext:@(task.terminationStatus)];
-		[self.standardErrorPipe.fileHandleForReading closeFile];
+		[standardError closeFile];
 	};
 
 	RACSubject *errorDataChunks = [[RACSubject subject] setNameWithFormat:@"errorDataChunks"];
 	self.standardErrorPipe.fileHandleForReading.readabilityHandler = ^(NSFileHandle *handle) {
-		[errorDataChunks sendNext:handle.availableData];
+		NSData *data = handle.availableData;
+		if (data.length == 0) {
+			handle.readabilityHandler = nil;
+			return;
+		}
+
+		[errorDataChunks sendNext:data];
 	};
 
 	_standardErrorData = [[[[[[errorDataChunks
@@ -91,7 +99,9 @@ const NSInteger SQRLZipArchiverShellTaskFailed = 1;
 
 - (void)dealloc {
 	[_taskTerminated sendCompleted];
-	[self.standardErrorPipe.fileHandleForReading closeFile];
+	NSFileHandle *standardError = self.standardErrorPipe.fileHandleForReading;
+	standardError.readabilityHandler = nil;
+	[standardError closeFile];
 }
 
 #pragma mark Archiving/Unarchiving

--- a/SquirrelTests/SQRLZipArchiverSpec.m
+++ b/SquirrelTests/SQRLZipArchiverSpec.m
@@ -17,6 +17,7 @@
 
 @interface SQRLZipArchiver (SQRLTestingHooks)
 @property (nonatomic, strong, readonly) NSTask *dittoTask;
+@property (nonatomic, strong, readonly) NSPipe *standardErrorPipe;
 - (RACSignal *)launchWithArguments:(NSArray *)arguments;
 @end
 
@@ -49,6 +50,18 @@ it(@"should error (not throw) when the ditto task fails to launch", ^{
 	expect(error.domain).to(equal(SQRLZipArchiverErrorDomain));
 	expect(@(error.code)).to(equal(@(SQRLZipArchiverShellTaskFailed)));
 	expect(error.userInfo[NSLocalizedDescriptionKey]).notTo(beNil());
+});
+
+it(@"should stop reading standard error once the ditto task has terminated", ^{
+	SQRLZipArchiver *archiver = [[SQRLZipArchiver alloc] init];
+	archiver.dittoTask.launchPath = @"/bin/sh";
+
+	NSError *error = nil;
+	BOOL success = [[archiver launchWithArguments:@[ @"-c", @"echo failure >&2; exit 1" ]] asynchronouslyWaitUntilCompleted:&error];
+
+	expect(@(success)).to(beFalsy());
+	expect(@(error.code)).to(equal(@(SQRLZipArchiverShellTaskFailed)));
+	expect(archiver.standardErrorPipe.fileHandleForReading.readabilityHandler).to(beNil());
 });
 
 it(@"should fail to extract a nonexistent zip archive", ^{


### PR DESCRIPTION
## Summary

`SQRLZipArchiver` installs an `NSFileHandle.readabilityHandler` on `ditto`'s stderr pipe and never removes it. Once the pipe reaches EOF, Foundation keeps invoking the handler with empty data until the handler is set to `nil`; each invocation is forwarded into the `collect` behind `standardErrorData`, so the array grows without bound until the host process dies. This change removes the handler as soon as `availableData` comes back empty, and detaches it before `closeFile` in both the termination handler and `dealloc`.

## Crash

Observed in a production Electron app on stock Electron 40.10.3 and 42.10.0 (both pin Squirrel.Mac `0e5d146`), on macOS 15.5 through 26.x. Symbolicated browser-process crash dumps all end in the same place:

```
partition_alloc::internal::PartitionExcessiveAllocationSize   (single allocation over the ~2 GiB direct-map limit)
CoreFoundation                                                (NSMutableArray growth)
-[RACSignal(Operations) collect]_block_invoke_2               RACSignal+Operations.m:369
-[RACSubject sendNext:]
-[SQRLZipArchiver init]_block_invoke                          Squirrel/SQRLZipArchiver.m:71
Foundation / libdispatch                                      (readability source)
```

Process telemetry for the same crashes shows the main process at roughly two cores with resident memory growing linearly for about eleven minutes after `ditto` exits, on machines whose update pipeline had otherwise finished. That is the signature of a handler spinning on an EOF pipe, and `closeFile` alone (added in #259 for the CPU-burn variant of the same loop, #247) is not enough to stop it.

## Change

- `SQRLZipArchiver.m`: the readability handler sets itself to `nil` and returns when `availableData` is empty; the termination handler and `dealloc` set it to `nil` before closing the file handle, which is the order Foundation documents for tearing down a handler.
- `SQRLZipArchiverSpec.m`: a spec runs a failing `/bin/sh` task through `launchWithArguments:` and asserts the handler is `nil` once the launch signal has completed.

Behaviour on the success and failure paths is unchanged: exit status and the stderr text collected before termination still flow into the error's `NSLocalizedDescription`.

## Relation to #324

#324 addresses the same crash and additionally caps the retained stderr at 1 MiB. This PR is the minimal form: only the handler lifecycle. If #324 lands first, this can be closed.

## Testing

The new spec runs under `script/test` in CI. I do not have a macOS machine available to run it locally.
